### PR TITLE
Copy Northgate personnel details to other repos

### DIFF
--- a/terraform/YJAF-POC-APP.tf
+++ b/terraform/YJAF-POC-APP.tf
@@ -5,12 +5,12 @@ module "YJAF-POC-APP" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/YJAF-POC.tf
+++ b/terraform/YJAF-POC.tf
@@ -5,22 +5,22 @@ module "YJAF-POC" {
     {
       github_user  = "oliviergaubert"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Olivier Gaubert"
+      email        = "Olivier.Gaubert@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-app-template.tf
+++ b/terraform/yjaf-app-template.tf
@@ -5,12 +5,12 @@ module "yjaf-app-template" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-assets.tf
+++ b/terraform/yjaf-assets.tf
@@ -5,52 +5,52 @@ module "yjaf-assets" {
     {
       github_user  = "oliviergaubert"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Olivier Gaubert"
+      email        = "Olivier.Gaubert@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-auth.tf
+++ b/terraform/yjaf-auth.tf
@@ -5,42 +5,42 @@ module "yjaf-auth" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-bands.tf
+++ b/terraform/yjaf-bands.tf
@@ -5,42 +5,42 @@ module "yjaf-bands" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-bed-unlock.tf
+++ b/terraform/yjaf-bed-unlock.tf
@@ -5,42 +5,42 @@ module "yjaf-bed-unlock" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-case.tf
+++ b/terraform/yjaf-case.tf
@@ -5,22 +5,22 @@ module "yjaf-case" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-cmm.tf
+++ b/terraform/yjaf-cmm.tf
@@ -5,12 +5,12 @@ module "yjaf-cmm" {
     {
       github_user  = "gregi2n"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-conversions.tf
+++ b/terraform/yjaf-conversions.tf
@@ -5,22 +5,22 @@ module "yjaf-conversions" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-csppi.tf
+++ b/terraform/yjaf-csppi.tf
@@ -5,12 +5,12 @@ module "yjaf-csppi" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-dal.tf
+++ b/terraform/yjaf-dal.tf
@@ -5,42 +5,42 @@ module "yjaf-dal" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-documents.tf
+++ b/terraform/yjaf-documents.tf
@@ -5,42 +5,42 @@ module "yjaf-documents" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-gateway.tf
+++ b/terraform/yjaf-gateway.tf
@@ -5,52 +5,52 @@ module "yjaf-gateway" {
     {
       github_user  = "brbaje-dev"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Ben Bajek"
+      email        = "ben.bajek@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-nginx-gateway.tf
+++ b/terraform/yjaf-nginx-gateway.tf
@@ -5,12 +5,12 @@ module "yjaf-nginx-gateway" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-nginx-pentaho.tf
+++ b/terraform/yjaf-nginx-pentaho.tf
@@ -5,12 +5,12 @@ module "yjaf-nginx-pentaho" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-placements.tf
+++ b/terraform/yjaf-placements.tf
@@ -5,42 +5,42 @@ module "yjaf-placements" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-refdata.tf
+++ b/terraform/yjaf-refdata.tf
@@ -5,22 +5,22 @@ module "yjaf-refdata" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-returns.tf
+++ b/terraform/yjaf-returns.tf
@@ -5,22 +5,22 @@ module "yjaf-returns" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-sentences.tf
+++ b/terraform/yjaf-sentences.tf
@@ -5,22 +5,22 @@ module "yjaf-sentences" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-transfers.tf
+++ b/terraform/yjaf-transfers.tf
@@ -5,32 +5,32 @@ module "yjaf-transfers" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-ui.tf
+++ b/terraform/yjaf-ui.tf
@@ -5,52 +5,52 @@ module "yjaf-ui" {
     {
       github_user  = "chris-nps"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Chris Sweeney"
+      email        = "chris.sweeney@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-views.tf
+++ b/terraform/yjaf-views.tf
@@ -5,32 +5,32 @@ module "yjaf-views" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-workflow.tf
+++ b/terraform/yjaf-workflow.tf
@@ -5,32 +5,32 @@ module "yjaf-workflow" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjaf-yp.tf
+++ b/terraform/yjaf-yp.tf
@@ -5,42 +5,42 @@ module "yjaf-yp" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "TomDover-NorthgatePS"
       permission   = "push"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Tom Dover"
+      email        = "tom.dover@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjsm-hub.tf
+++ b/terraform/yjsm-hub.tf
@@ -5,42 +5,42 @@ module "yjsm-hub" {
     {
       github_user  = "oliviergaubert"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Olivier Gaubert"
+      email        = "Olivier.Gaubert@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjsm-hubadmin.tf
+++ b/terraform/yjsm-hubadmin.tf
@@ -5,42 +5,42 @@ module "yjsm-hubadmin" {
     {
       github_user  = "oliviergaubert"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Olivier Gaubert"
+      email        = "Olivier.Gaubert@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "AndrewRichards72"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Andrew Richards"
+      email        = "andrew.richards@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }

--- a/terraform/yjsm-ui.tf
+++ b/terraform/yjsm-ui.tf
@@ -5,22 +5,22 @@ module "yjsm-ui" {
     {
       github_user  = "gregi2n"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Greg Whiting"
+      email        = "greg.whiting@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
     {
       github_user  = "griffinjuknps"
       permission   = "admin"
-      name         = "" #  The name of the person behind github_user
-      email        = "" #  Their email address
-      org          = "" #  The organisation/entity they belong to
-      reason       = "" #  Why is this person being granted access?
-      added_by     = "" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "" #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jeremy Griffin"
+      email        = "jeremy.griffin@northgateps.com"
+      org          = "Northgate"
+      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
+      added_by     = "<gareth.davies@digital.justice.gov.uk> on behalf of the YJB"
+      review_after = "2021-12-11"
     },
   ]
 }


### PR DESCRIPTION
This takes the personnel details and other 
metadata provided in #14 and copies them to the 
other repositories to which the same github 
usernames have access.