### PR TITLE
After making changes, update the OpsEng report

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -27,3 +27,9 @@ jobs:
           cd terraform
           terraform init
           terraform apply -auto-approve
+      - name: Update OpsEng collaborators report
+        run: bin/post-data.sh
+        env:
+          ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          OPERATIONS_ENGINEERING_REPORTS_API_KEY: ${{ secrets.OPERATIONS_ENGINEERING_REPORTS_API_KEY }}
+          OPS_ENG_REPORTS_URL: "https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/github_collaborators"


### PR DESCRIPTION
We update the report daily, to pick up any changes to collaborators that
have been made by users.

This change also posts an update to the report after we merge any
changes to this repository, so that the report is up to date wrt. those
changes, too.
