### PR TITLE
Allow comments in terraform source

### DIFF
--- a/lib/github_collaborators/terraform_collaborator.rb
+++ b/lib/github_collaborators/terraform_collaborator.rb
@@ -120,9 +120,12 @@ class GithubCollaborators
     end
 
     def get_value(val)
-      if m = /#{val}.*"([^"]+)"$/.match(collaborator_source)
-        m[1]
+      collaborator_source.split("\n").grep(/#{val}\s+=/).each do |line|
+        if m = /#{val}.*"([^"]+?)"/.match(line)
+          return m[1]
+        end
       end
+      nil
     end
   end
 end

--- a/spec/terraform_collaborator_spec.rb
+++ b/spec/terraform_collaborator_spec.rb
@@ -43,15 +43,15 @@ EOF
 
     let(:tfsource) {
       <<~EOF
-      module "acronyms" {
-        source     = "./modules/repository-collaborators"
-        repository = "acronyms"
-        collaborators = [
-      #{matthewtansini}
-      #{detailsmissing}
-      #{malformed_date}
-        ]
-      }
+        module "acronyms" {
+          source     = "./modules/repository-collaborators"
+          repository = "acronyms"
+          collaborators = [
+        #{matthewtansini}
+        #{detailsmissing}
+        #{malformed_date}
+          ]
+        }
       EOF
     }
 

--- a/spec/terraform_collaborator_spec.rb
+++ b/spec/terraform_collaborator_spec.rb
@@ -11,7 +11,7 @@ class GithubCollaborators
       email        = "matt.tans@not.real.email"
       org          = "MoJ"
       reason       = "A really good reason"
-      added_by     = "David Salgado <david.salgado@digital.justice.gov.uk>"
+      added_by     = "David Salgado <david.salgado@digital.justice.gov.uk>" # TODO: whatever
       review_after = "#{review_date}"
     },
 EOF


### PR DESCRIPTION
Prior to this change, there was an implicit
requirement for any supplied values to have
nothing after the closing quote. So, this would be
fine:

```
   foo = "bar"
```

...but this would count as missing the value of
`foo`:

```
   foo = "bar" # some comment here
```

With this change, such comments will be ignored,
as they should be.

Although other text on the same line will also be
allowed, the combination of `terraform fmt` and
`terraform plan` which runs on every PR should 
prevent malformed code from getting through.