### PR TITLE
Disable "apply on merge"

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,10 +1,10 @@
 name: Terraform apply
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths: 'terraform/**'
+#  push:
+#    branches:
+#      - main
+#    paths: 'terraform/**'
 
 env:
   AWS_REGION:  "eu-west-2"


### PR DESCRIPTION
While I'm generating lots of PRs for individual changes, I don't want lots of `terraform apply` commands running in parallel, or to have to wait 5 minutes between each PR merge.

So, I'm temporarily disabling this bit of automation - I'll use the workflow-dispatch trigger to run the terraform apply for every few changes, rather than for each change.