### PR TITLE
Terraform: state-locking & change location

### DIFF
--- a/.github/workflows/targeted-terraform-plan.yml
+++ b/.github/workflows/targeted-terraform-plan.yml
@@ -8,6 +8,7 @@ on:
 env:
   AWS_REGION:  "eu-west-2"
   S3_BUCKET_NAME: "cloud-platform-36623f774b9641d8697d65bdf6b030f5"
+  DYNAMODB_TABLE: "cp-b6970ba60ed66537"
   TERRAFORM: terraform
   AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -25,7 +25,7 @@ jobs:
           terraform_version: 0.13.5
       - run: |
           cd terraform
-          terraform init
+          terraform init -backend-config="bucket=${S3_BUCKET_NAME}"
           terraform apply -auto-approve
       - name: Update OpsEng collaborators report
         run: bin/post-data.sh

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -9,6 +9,7 @@ on:
 env:
   AWS_REGION:  "eu-west-2"
   S3_BUCKET_NAME: "cloud-platform-36623f774b9641d8697d65bdf6b030f5"
+  DYNAMODB_TABLE: "cp-b6970ba60ed66537"
   TERRAFORM: terraform
   AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -25,7 +26,7 @@ jobs:
           terraform_version: 0.13.5
       - run: |
           cd terraform
-          terraform init -backend-config="bucket=${S3_BUCKET_NAME}"
+          terraform init -backend-config="bucket=${S3_BUCKET_NAME}" -backend-config="dynamodb_table=${DYNAMODB_TABLE}"
           terraform apply -auto-approve
       - name: Update OpsEng collaborators report
         run: bin/post-data.sh

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -5,6 +5,7 @@ on:
 env:
   AWS_REGION:  "eu-west-2"
   S3_BUCKET_NAME: "cloud-platform-36623f774b9641d8697d65bdf6b030f5"
+  DYNAMODB_TABLE: "cp-b6970ba60ed66537"
   TERRAFORM: terraform
   AWS_ACCESS_KEY_ID:  ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY:  ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -22,5 +23,5 @@ jobs:
       - name: terraform plan
         run: |
           cd terraform
-          terraform init -backend-config="bucket=${S3_BUCKET_NAME}"
+          terraform init -backend-config="bucket=${S3_BUCKET_NAME}" -backend-config="dynamodb_table=${DYNAMODB_TABLE}"
           terraform plan

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -22,5 +22,5 @@ jobs:
       - name: terraform plan
         run: |
           cd terraform
-          terraform init
+          terraform init -backend-config="bucket=${S3_BUCKET_NAME}"
           terraform plan

--- a/scripts/targeted-plan.sh
+++ b/scripts/targeted-plan.sh
@@ -14,7 +14,7 @@ main() {
   cd terraform
   echo "Running terraform init"
   # Suppress init output, unless it fails
-  output=$(${TERRAFORM} init -input=false 2>&1) || (echo "$output" && false)
+  output=$(${TERRAFORM} init -input=false -backend-config="bucket=${S3_BUCKET_NAME}" 2>&1) || (echo "$output" && false)
 
   for r in $(changed_repositories); do
     echo "Running terraform plan for ${r}"

--- a/scripts/targeted-plan.sh
+++ b/scripts/targeted-plan.sh
@@ -14,7 +14,7 @@ main() {
   cd terraform
   echo "Running terraform init"
   # Suppress init output, unless it fails
-  output=$(${TERRAFORM} init -input=false -backend-config="bucket=${S3_BUCKET_NAME}" 2>&1) || (echo "$output" && false)
+  output=$(${TERRAFORM} init -input=false -backend-config="bucket=${S3_BUCKET_NAME}" -backend-config="dynamodb_table=${DYNAMODB_TABLE}" 2>&1) || (echo "$output" && false)
 
   for r in $(changed_repositories); do
     echo "Running terraform plan for ${r}"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,7 +3,7 @@ terraform {
   # - S3 bucket name, which is created [here](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/s3.tf)
   backend "s3" {
     encrypt = true
-    key     = "terraform.tfstate"
+    key     = "github-collaborators/terraform.tfstate"
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,10 +2,8 @@ terraform {
   # `backend` blocks do not support variables, so the following are hard-coded here:
   # - S3 bucket name, which is created [here](https://github.com/ministryofjustice/cloud-platform-environments/blob/main/namespaces/live-1.cloud-platform.service.justice.gov.uk/operations-engineering/resources/s3.tf)
   backend "s3" {
-    bucket  = "cloud-platform-36623f774b9641d8697d65bdf6b030f5"
     encrypt = true
     key     = "terraform.tfstate"
-    region  = "eu-west-2"
   }
 }
 


### PR DESCRIPTION
- Remove `bucket` and `region` from `main.tf`
- Use DynamoDB table to lock terraform state
- Move the terraform state to a new path in S3
