### PR TITLE
Remove undefined collaborators

### DIFF
--- a/.github/workflows/post-data.yaml
+++ b/.github/workflows/post-data.yaml
@@ -14,3 +14,9 @@ jobs:
           ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           OPERATIONS_ENGINEERING_REPORTS_API_KEY: ${{ secrets.OPERATIONS_ENGINEERING_REPORTS_API_KEY }}
           OPS_ENG_REPORTS_URL: "https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/github_collaborators"
+      - name: Remove manually-added collaborators
+        run: bin/remove-undefined-collaborators.rb
+        env:
+          ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          OWNER: "ministryofjustice"
+          OPS_ENG_REPORTS_URL: "https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/github_collaborators"

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Raise and merge a PR removing the collaborator from the list of collaborators in
 
 This will be the case if access was granted by a repository administrator via the github UI.
 
+> You should not need to do this manually - there is a github action which runs daily, and removes all collaborators who are not defined in terraform code.
+
 To remove such a collaborator, use [this GitHub Action](https://github.com/ministryofjustice/github-collaborators/actions?query=workflow%3A%22Remove+a+collaborator%22)
 
 ![GitHub Action UI image](doc/images/github-action.png)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Manage MoJ GitHub external collaborators via code.
 
+## Requesting collaborator access
+
+If you want to allow access to an MoJ GitHub repository for an external collaborator, please raise a pull request making the required changes to the corresponding `terraform/[repository-name].tf` file in this repository.
+
+If you are not confident editing terraform code, you can [raise an issue](https://github.com/ministryofjustice/github-collaborators/issues/new?labels=Access+Request&template=access-request.md) to request access for a collaborator, and we will make the changes for you.
+
 ## Background
 
 Sometimes we need to grant access to one of more of our github repositories to people who are not part of the "ministryofjustice" github organisation. This often happens when we engage third-party suppliers to carry out work on our behalf.
@@ -13,6 +19,7 @@ Rather than manage this via "clickops" this repository enables us to manage thes
 ## How it works
 
 * The `terraform/` directory contains a file per repository that has collaborators, defining the collaboration with metadata. The name of the file is the repository name with any `.` characters replaced with `-` to render the name acceptable for terraform. i.e. the file for repository `foo.bar` will be `terraform/foo-bar.tf`
+
 * Github actions run `terraform plan` and `terraform apply` to keep the collaborations in GitHub in sync with the terraform source code
 * Ruby code in the `bin/` and `lib/` directories (with unit tests in the `spec/` directory) queries GitHub via the GraphQL API and retrieves all the collaborator relationships which exist
 * A github action runs periodically and compares the collaborators in GitHub with the terraform source code. Any collaborators which are not fully specified in the terraform source code are included in a JSON report which is the basis for [this report].

--- a/bin/remove-undefined-collaborators.rb
+++ b/bin/remove-undefined-collaborators.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+
+# Fetch the "insufficiently defined collaborators" report as JSON, and remove
+# any collaborators who are not defined in terraform.
+
+require_relative "../lib/github_collaborators"
+
+OWNER = "ministryofjustice"
+REPORT_URL = "https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/github_collaborators"
+
+def remove_collaborator(hash)
+  repository = hash.fetch("repository")
+  github_user = hash.fetch("login")
+
+  puts "Removing collaborator #{login} from repository #{repository}"
+
+  params = {
+    owner: OWNER,
+    repository: repository,
+    github_user: login,
+  }
+
+  # We must create the issue before removing access, because the issue is
+  # assigned to the removed collaborator, so that they (hopefully) get a
+  # notification about it.
+  GithubCollaborators::IssueCreator.new(params).create
+  GithubCollaborators::AccessRemover.new(params).remove
+end
+
+json = GithubCollaborators::HttpClient.new.fetch_json(REPORT_URL).body
+
+JSON.parse(json)
+  .fetch("data")
+  .filter { |c| !c["defined_in_terraform"] }
+  .map { |c| remove_collaborator(c) }

--- a/bin/remove-undefined-collaborators.rb
+++ b/bin/remove-undefined-collaborators.rb
@@ -5,9 +5,6 @@
 
 require_relative "../lib/github_collaborators"
 
-OWNER = "ministryofjustice"
-REPORT_URL = "https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/github_collaborators"
-
 def remove_collaborator(hash)
   repository = hash.fetch("repository")
   github_user = hash.fetch("login")
@@ -15,7 +12,7 @@ def remove_collaborator(hash)
   puts "Removing collaborator #{login} from repository #{repository}"
 
   params = {
-    owner: OWNER,
+    owner: ENV.fetch("OWNER"),
     repository: repository,
     github_user: login,
   }
@@ -27,7 +24,10 @@ def remove_collaborator(hash)
   GithubCollaborators::AccessRemover.new(params).remove
 end
 
-json = GithubCollaborators::HttpClient.new.fetch_json(REPORT_URL).body
+############################################################
+
+url = ENV.fetch("OPS_ENG_REPORTS_URL")
+json = GithubCollaborators::HttpClient.new.fetch_json(url).body
 
 JSON.parse(json)
   .fetch("data")

--- a/lib/github_collaborators.rb
+++ b/lib/github_collaborators.rb
@@ -13,6 +13,9 @@ require_relative "./github_collaborators/repositories"
 require_relative "./github_collaborators/organization_external_collaborators"
 require_relative "./github_collaborators/repository_collaborator_importer"
 require_relative "./github_collaborators/terraform_collaborator"
+require_relative "./github_collaborators/access_remover"
+require_relative "./github_collaborators/issue_creator"
+require_relative "./github_collaborators/http_client"
 
 PAGE_SIZE = 100
 

--- a/lib/github_collaborators/access_remover.rb
+++ b/lib/github_collaborators/access_remover.rb
@@ -1,0 +1,16 @@
+class GithubCollaborators
+  class AccessRemover
+    attr_reader :owner, :repository, :github_user
+
+    def initialize(params)
+      @owner = params.fetch(:owner)
+      @repository = params.fetch(:repository)
+      @github_user = params.fetch(:github_user)
+    end
+
+    def remove
+      url = "https://api.github.com/repos/#{owner}/#{repository}/collaborators/#{github_user}"
+      HttpClient.new.delete(url)
+    end
+  end
+end

--- a/lib/github_collaborators/http_client.rb
+++ b/lib/github_collaborators/http_client.rb
@@ -1,0 +1,39 @@
+class GithubCollaborators
+  class HttpClient
+    attr_reader :token
+
+    def initialize(params = {})
+      token = params.fetch(:token, ENV.fetch("ADMIN_GITHUB_TOKEN"))
+    end
+
+    def post_json(url, json)
+      http, uri = client(url)
+      request = Net::HTTP::Post.new(uri.request_uri, headers)
+      request.body = json
+      http.request(request)
+    end
+
+    def delete(url)
+      http, uri = client(url)
+      request = Net::HTTP::Delete.new(uri.request_uri, headers)
+      http.request(request)
+    end
+
+    private
+
+    def client(url)
+      uri = URI.parse(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = true
+      [http, uri]
+    end
+
+    def headers
+      {
+        "Content-Type" => "application/json",
+        "Authorization" => "token #{token}",
+      }
+    end
+  end
+end
+

--- a/lib/github_collaborators/http_client.rb
+++ b/lib/github_collaborators/http_client.rb
@@ -6,6 +6,12 @@ class GithubCollaborators
       token = params.fetch(:token, ENV.fetch("ADMIN_GITHUB_TOKEN"))
     end
 
+    def fetch_json(url)
+      http, uri = client(url)
+      request = Net::HTTP::Get.new(uri.request_uri, headers)
+      http.request(request)
+    end
+
     def post_json(url, json)
       http, uri = client(url)
       request = Net::HTTP::Post.new(uri.request_uri, headers)
@@ -30,6 +36,7 @@ class GithubCollaborators
 
     def headers
       {
+        "Accept" => "application/json",
         "Content-Type" => "application/json",
         "Authorization" => "token #{token}",
       }

--- a/lib/github_collaborators/issue_creator.rb
+++ b/lib/github_collaborators/issue_creator.rb
@@ -1,0 +1,35 @@
+class GithubCollaborators
+  class IssueCreator
+    attr_reader :owner, :repository, :github_user
+
+    def initialize(params)
+      @owner = params.fetch(:owner)
+      @repository = params.fetch(:repository)
+      @github_user = params.fetch(:github_user)
+    end
+
+    def create
+      url = "https://api.github.com/repos/#{owner}/#{repository}/issues"
+      HttpClient.new.post_json(url, issue_hash.to_json)
+    end
+
+    private
+
+    def issue_hash
+      {
+        title: "Please define external collaborators in code",
+        assignees: [ github_user ],
+        body: <<EOF
+Hi there
+
+We now have a process to manage github collaborators in code:
+https://github.com/ministryofjustice/github-collaborators/blob/main/README.md#github-external-collaborators
+
+Please follow the procedure described there to grant @#{github_user} access to this repository.
+
+If you have any questions, please post in #ask-operations-engineering on Slack.
+EOF
+      }
+    end
+  end
+end

--- a/lib/github_collaborators/terraform_collaborator.rb
+++ b/lib/github_collaborators/terraform_collaborator.rb
@@ -59,7 +59,8 @@ class GithubCollaborators
         "login" => login,
         "status" => status,
         "issues" => issues,
-        "href" => href
+        "href" => href,
+        "defined_in_terraform" => exists?,
       }
     end
 

--- a/lib/github_collaborators/terraform_collaborator.rb
+++ b/lib/github_collaborators/terraform_collaborator.rb
@@ -34,16 +34,6 @@ class GithubCollaborators
       @base_url = params.fetch(:base_url) # URL of the github UI page listing all the terraform files
     end
 
-    def remove
-      hash = {
-        owner: "ministryofjustice",
-        repository: repository,
-        github_user: login,
-      }
-      IssueCreator.new(hash).create
-      AccessRemover.new(hash).remove
-    end
-
     def exists?
       collaborator_source != nil
     end

--- a/spec/access_remover_spec.rb
+++ b/spec/access_remover_spec.rb
@@ -1,0 +1,21 @@
+class GithubCollaborators
+  describe AccessRemover do
+    let(:params) { {
+      owner: "ministryofjustice",
+      repository: "somerepo",
+      github_user: "somegithubuser",
+    } }
+
+    subject(:ar) { described_class.new(params) }
+
+    let(:http_client) { double(HttpClient) }
+
+    it "calls github api" do
+      url = "https://api.github.com/repos/ministryofjustice/somerepo/collaborators/somegithubuser"
+      expect(HttpClient).to receive(:new).and_return(http_client)
+      expect(http_client).to receive(:delete).with(url)
+
+      ar.remove
+    end
+  end
+end

--- a/spec/issue_creator_spec.rb
+++ b/spec/issue_creator_spec.rb
@@ -1,0 +1,25 @@
+class GithubCollaborators
+  describe IssueCreator do
+    let(:params) { {
+      owner: "ministryofjustice",
+      repository: "somerepo",
+      github_user: "somegithubuser",
+    } }
+
+    subject(:ic) { described_class.new(params) }
+
+    let(:http_client) { double(HttpClient) }
+
+    let(:json) {
+      %[{"title":"Please define external collaborators in code","assignees":["somegithubuser"],"body":"Hi there\\n\\nWe now have a process to manage github collaborators in code:\\nhttps://github.com/ministryofjustice/github-collaborators/blob/main/README.md#github-external-collaborators\\n\\nPlease follow the procedure described there to grant @somegithubuser access to this repository.\\n\\nIf you have any questions, please post in #ask-operations-engineering on Slack.\\n"}]
+    }
+
+    it "calls github api" do
+      url = "https://api.github.com/repos/ministryofjustice/somerepo/issues"
+      expect(HttpClient).to receive(:new).and_return(http_client)
+      expect(http_client).to receive(:post_json).with(url, json)
+
+      ic.create
+    end
+  end
+end

--- a/spec/terraform_collaborator_spec.rb
+++ b/spec/terraform_collaborator_spec.rb
@@ -68,45 +68,6 @@ EOF
 
     subject(:tc) { described_class.new(params) }
 
-    context "removing" do
-      let(:ar) { double(AccessRemover) }
-      let(:ic) { double(IssueCreator) }
-      let(:login) { "somegithubuser" }
-
-      let(:ar_params) { {
-          owner: "ministryofjustice",
-          repository: repository,
-          github_user: login,
-      } }
-
-      before do
-        allow(AccessRemover).to receive(:new).and_return(ar)
-        allow(IssueCreator).to receive(:new).and_return(ic)
-        allow(ar).to receive(:remove)
-        allow(ic).to receive(:create)
-      end
-
-      it "uses IssueCreator" do
-        expect(IssueCreator).to receive(:new).with hash_including(ar_params)
-        tc.remove
-      end
-
-      it "uses AccessRemover" do
-        expect(AccessRemover).to receive(:new).with hash_including(ar_params)
-        tc.remove
-      end
-
-      it "removes collaborator" do
-        expect(AccessRemover).to receive(:new).with hash_including(ar_params)
-        tc.remove
-      end
-
-      it "creates an issue" do
-        expect(ic).to receive(:create)
-        tc.remove
-      end
-    end
-
     context "when there is no terraform source file" do
       let(:params) {
         {

--- a/spec/terraform_collaborator_spec.rb
+++ b/spec/terraform_collaborator_spec.rb
@@ -183,10 +183,15 @@ EOF
             "Collaborator reason is missing",
             "Person who added this collaborator is missing",
             "Collaboration review date is missing"
-          ]
+          ],
+          "defined_in_terraform" => true,
         }
 
         expect(tc.to_hash).to eq(expected)
+      end
+
+      it "sets defined_in_terraform to true" do
+        expect(tc.to_hash["defined_in_terraform"]).to be(true)
       end
     end
 
@@ -201,6 +206,10 @@ EOF
 
       it "has an issue" do
         expect(tc.issues).to eq(["Collaborator not defined in terraform"])
+      end
+
+      it "sets defined_in_terraform to false" do
+        expect(tc.to_hash["defined_in_terraform"]).to be(false)
       end
     end
 


### PR DESCRIPTION
This PR adds code and github actions config. to remove access for any collaborators who are not defined in terraform code.

This means anyone who has been manually granted access to a repo, via the github UI, will have their access revoked overnight.

An issue is created, in the relevant repo, explaining how to get access which will not be removed.

- Add TerraformCollaborator#remove method
- Add code to remove collaborators
- Add ruby script to remove undefined collaborators
- Update script: take all config from ENV vars.
- Remove undefined collabs after report is updated
