### PR TITLE
Remove duplicate entries; chris-nps, mat-nps

### DIFF
--- a/terraform/yjaf-ui.tf
+++ b/terraform/yjaf-ui.tf
@@ -102,25 +102,5 @@ module "yjaf-ui" {
       added_by     = "Greg Whiting <greg.whiting@northgateps.com> Devops for northgate"
       review_after = "2021-12-01"
     },
-    {
-      github_user  = "chris-nps"
-      permission   = "push"
-      name         = "Chris Sweeney"
-      email        = "chris.sweeney@northgateps.com"
-      org          = "NPS (northgate)"
-      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
-      added_by     = "Greg Whiting <greg.whiting@northgateps.com> Devops for northgate"
-      review_after = "2021-12-31"
-    },
-    {
-      github_user  = "mat-nps"
-      permission   = "push"
-      name         = "Mat Kamil"
-      email        = "mat.kamil@northgateps.com"
-      org          = "NPS (northgate)"
-      reason       = "Part of the Northgate supplier team for the YJB YJAF system"
-      added_by     = "Greg Whiting <greg.whiting@northgateps.com> Devops for northgate"
-      review_after = "2021-12-31"
-    },
   ]
 }


### PR DESCRIPTION
terraform fails if there are duplicated entries using the same value for
`github_user`, in the same repository.

i.e. you can't grant a user access to a repo multiple times.
