### PR TITLE
Update env var for  to post data to the correct URL

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -33,4 +33,5 @@ jobs:
         env:
           ADMIN_GITHUB_TOKEN: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           OPERATIONS_ENGINEERING_REPORTS_API_KEY: ${{ secrets.OPERATIONS_ENGINEERING_REPORTS_API_KEY }}
-          OPS_ENG_REPORTS_URL: "https://operations-engineering-reports.cloud-platform.service.justice.gov.uk/github_collaborators"
+          OPERATIONS_ENGINEERING_REPORTS_HOST: ${{ secrets.OPERATIONS_ENGINEERING_REPORTS_HOST }}
+          OPS_ENG_REPORTS_URL: ${{ secrets.OPERATIONS_ENGINEERING_REPORTS_HOST }}/github_collaborators


### PR DESCRIPTION
[Commit 09d996](https://github.com/ministryofjustice/github-collaborators/commit/2575d4b1705df2ca5a7274c768eedd546e09d996) replaced `OPS_ENG_REPORTS_URL` with `OPERATIONS_ENGINEERING_REPORTS_HOST` as the environment variable for `bin/post-data.sh`.

This PR adds the new environment variable to the terraform-apply.yml GitHub workflow, which [fails](https://github.com/ministryofjustice/github-collaborators/runs/1950157529) because the (correct) environment variable cannot be found.