### PR TITLE
Replicate hmpps-jenkins-admin team for collaborator

### DIFF
--- a/terraform/ansible-users.tf
+++ b/terraform/ansible-users.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "ansible-users" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "ansible-users"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/community-api.tf
+++ b/terraform/community-api.tf
@@ -1,20 +1,10 @@
-module "hmpps-cporacle-application" {
+module "community-api" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "community-api"
   collaborators = [
     {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
-    {
       github_user  = "swestb"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Stuart Westbrook"                                                                                                                      #  The name of the person behind github_user
       email        = "stuart.westbrook@adrocgroup.com"                                                                                                       #  Their email address
       org          = "Adroc Group"                                                                                                                           #  The organisation/entity they belong to

--- a/terraform/delius-manual-deployments.tf
+++ b/terraform/delius-manual-deployments.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "delius-manual-deployments" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "delius-manual-deployments"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/delius-versions-dashboard.tf
+++ b/terraform/delius-versions-dashboard.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "delius-versions-dashboard" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "delius-versions-dashboard"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/delius-versions.tf
+++ b/terraform/delius-versions.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "delius-versions" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "delius-versions"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/delius.tf
+++ b/terraform/delius.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "delius" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "delius"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-accounts-refresh.tf
+++ b/terraform/hmpps-accounts-refresh.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-accounts-refresh" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-accounts-refresh"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-alfresco-bootstrap.tf
+++ b/terraform/hmpps-alfresco-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-alfresco-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-alfresco-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-alfresco-docker.tf
+++ b/terraform/hmpps-alfresco-docker.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-alfresco-docker" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-alfresco-docker"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-alfresco-infra-versions.tf
+++ b/terraform/hmpps-alfresco-infra-versions.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-alfresco-infra-versions" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-alfresco-infra-versions"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-alfresco-installer-builder.tf
+++ b/terraform/hmpps-alfresco-installer-builder.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-alfresco-installer-builder" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-alfresco-installer-builder"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-alfresco-installer.tf
+++ b/terraform/hmpps-alfresco-installer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-alfresco-installer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-alfresco-installer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-alfresco-packer.tf
+++ b/terraform/hmpps-alfresco-packer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-alfresco-packer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-alfresco-packer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-alfresco.tf
+++ b/terraform/hmpps-alfresco.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-alfresco" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-alfresco"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-ansible-esadmin-role.tf
+++ b/terraform/hmpps-ansible-esadmin-role.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-ansible-esadmin-role" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-ansible-esadmin-role"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-ansible-packages.tf
+++ b/terraform/hmpps-ansible-packages.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-ansible-packages" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-ansible-packages"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-ansible-playbooks.tf
+++ b/terraform/hmpps-ansible-playbooks.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-ansible-playbooks" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-ansible-playbooks"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-ansible-role-solr.tf
+++ b/terraform/hmpps-ansible-role-solr.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-ansible-role-solr" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-ansible-role-solr"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-ansible-roles.tf
+++ b/terraform/hmpps-ansible-roles.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-ansible-roles" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-ansible-roles"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-base-packer-pipeline.tf
+++ b/terraform/hmpps-base-packer-pipeline.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-base-packer-pipeline" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-base-packer-pipeline"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-base-packer.tf
+++ b/terraform/hmpps-base-packer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-base-packer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-base-packer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-beats-monitoring.tf
+++ b/terraform/hmpps-beats-monitoring.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-beats-monitoring" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-beats-monitoring"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-bootstrap.tf
+++ b/terraform/hmpps-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-clamav-ecs-stack.tf
+++ b/terraform/hmpps-clamav-ecs-stack.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-clamav-ecs-stack" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-clamav-ecs-stack"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-cr-ancillary-cp-oracle.tf
+++ b/terraform/hmpps-cr-ancillary-cp-oracle.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-cr-ancillary-cp-oracle" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-cr-ancillary-cp-oracle"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-cr-ancillary-cporacle.tf
+++ b/terraform/hmpps-cr-ancillary-cporacle.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-cr-ancillary-cporacle" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-cr-ancillary-cporacle"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-cr-ancillary-jira-ansible.tf
+++ b/terraform/hmpps-cr-ancillary-jira-ansible.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-cr-ancillary-jira-ansible" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-cr-ancillary-jira-ansible"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-cr-ancillary-jira.tf
+++ b/terraform/hmpps-cr-ancillary-jira.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-cr-ancillary-jira" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-cr-ancillary-jira"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-cr-ancillary-jitbit.tf
+++ b/terraform/hmpps-cr-ancillary-jitbit.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-cr-ancillary-jitbit" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-cr-ancillary-jitbit"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-cr-ancillary-network.tf
+++ b/terraform/hmpps-cr-ancillary-network.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-cr-ancillary-network" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-cr-ancillary-network"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-alfresco-shared-terraform.tf
+++ b/terraform/hmpps-delius-alfresco-shared-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-alfresco-shared-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-alfresco-shared-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-ansible.tf
+++ b/terraform/hmpps-delius-ansible.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-ansible" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-ansible"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-bastion.tf
+++ b/terraform/hmpps-delius-bastion.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-bastion" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-bastion"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-389ds-bootstrap.tf
+++ b/terraform/hmpps-delius-core-389ds-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-389ds-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-389ds-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-ansible.tf
+++ b/terraform/hmpps-delius-core-ansible.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-ansible" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-ansible"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-apacheds-bootstrap.tf
+++ b/terraform/hmpps-delius-core-apacheds-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-apacheds-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-apacheds-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-apacheds-installer.tf
+++ b/terraform/hmpps-delius-core-apacheds-installer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-apacheds-installer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-apacheds-installer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-app-scripts.tf
+++ b/terraform/hmpps-delius-core-app-scripts.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-app-scripts" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-app-scripts"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-bootstrap.tf
+++ b/terraform/hmpps-delius-core-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-build.tf
+++ b/terraform/hmpps-delius-core-build.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-build" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-build"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-ldap-bootstrap.tf
+++ b/terraform/hmpps-delius-core-ldap-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-ldap-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-ldap-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-oracledb-bootstrap.tf
+++ b/terraform/hmpps-delius-core-oracledb-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-oracledb-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-oracledb-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-oracledb-installer.tf
+++ b/terraform/hmpps-delius-core-oracledb-installer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-oracledb-installer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-oracledb-installer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-packer.tf
+++ b/terraform/hmpps-delius-core-packer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-packer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-packer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-system-user.tf
+++ b/terraform/hmpps-delius-core-system-user.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-system-user" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-system-user"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-terraform.tf
+++ b/terraform/hmpps-delius-core-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-training-scripts.tf
+++ b/terraform/hmpps-delius-core-training-scripts.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-training-scripts" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-training-scripts"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-umt-bootstrap.tf
+++ b/terraform/hmpps-delius-core-umt-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-umt-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-umt-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-core-weblogic-installer.tf
+++ b/terraform/hmpps-delius-core-weblogic-installer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-core-weblogic-installer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-core-weblogic-installer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-dss-offloc-docker.tf
+++ b/terraform/hmpps-delius-dss-offloc-docker.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-dss-offloc-docker" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-dss-offloc-docker"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-iaps-packer.tf
+++ b/terraform/hmpps-delius-iaps-packer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-iaps-packer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-iaps-packer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-iaps-shared-terraform.tf
+++ b/terraform/hmpps-delius-iaps-shared-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-iaps-shared-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-iaps-shared-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-mis-installer.tf
+++ b/terraform/hmpps-delius-mis-installer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-mis-installer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-mis-installer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-mis-packer.tf
+++ b/terraform/hmpps-delius-mis-packer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-mis-packer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-mis-packer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-network-terraform.tf
+++ b/terraform/hmpps-delius-network-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-network-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-network-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-new-tech-shared-terraform.tf
+++ b/terraform/hmpps-delius-new-tech-shared-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-new-tech-shared-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-new-tech-shared-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-new-tech-terraform.tf
+++ b/terraform/hmpps-delius-new-tech-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-new-tech-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-new-tech-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-oracledb-ha.tf
+++ b/terraform/hmpps-delius-oracledb-ha.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-oracledb-ha" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-oracledb-ha"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-pipelines.tf
+++ b/terraform/hmpps-delius-pipelines.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-pipelines" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-pipelines"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-po-alfresco-proxy.tf
+++ b/terraform/hmpps-delius-po-alfresco-proxy.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-po-alfresco-proxy" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-po-alfresco-proxy"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-psnproxy-packer.tf
+++ b/terraform/hmpps-delius-psnproxy-packer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-psnproxy-packer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-psnproxy-packer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-psnproxy-terraform.tf
+++ b/terraform/hmpps-delius-psnproxy-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-psnproxy-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-psnproxy-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-certificate-orchestration.tf
+++ b/terraform/hmpps-delius-spg-certificate-orchestration.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-certificate-orchestration" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-certificate-orchestration"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-codepipeline.tf
+++ b/terraform/hmpps-delius-spg-codepipeline.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-codepipeline" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-codepipeline"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-common-stack.tf
+++ b/terraform/hmpps-delius-spg-common-stack.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-common-stack" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-common-stack"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-proxy.tf
+++ b/terraform/hmpps-delius-spg-proxy.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-proxy" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-proxy"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-shared-terraform.tf
+++ b/terraform/hmpps-delius-spg-shared-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-shared-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-shared-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-testing-bdd-tests.tf
+++ b/terraform/hmpps-delius-spg-testing-bdd-tests.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-testing-bdd-tests" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-testing-bdd-tests"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-testing-payload-generator.tf
+++ b/terraform/hmpps-delius-spg-testing-payload-generator.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-testing-payload-generator" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-testing-payload-generator"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-testing-performance-tests.tf
+++ b/terraform/hmpps-delius-spg-testing-performance-tests.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-testing-performance-tests" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-testing-performance-tests"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-testing-secure-httpclient.tf
+++ b/terraform/hmpps-delius-spg-testing-secure-httpclient.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-testing-secure-httpclient" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-testing-secure-httpclient"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-testing-smoke-tests.tf
+++ b/terraform/hmpps-delius-spg-testing-smoke-tests.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-testing-smoke-tests" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-testing-smoke-tests"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-spg-testing-wiremock-extended.tf
+++ b/terraform/hmpps-delius-spg-testing-wiremock-extended.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-spg-testing-wiremock-extended" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-spg-testing-wiremock-extended"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-test-test-loadrunner.tf
+++ b/terraform/hmpps-delius-test-test-loadrunner.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-test-test-loadrunner" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-test-test-loadrunner"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius-transit-gateway.tf
+++ b/terraform/hmpps-delius-transit-gateway.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius-transit-gateway" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius-transit-gateway"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-delius.tf
+++ b/terraform/hmpps-delius.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-delius" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-delius"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-engineering-jira-bootstrap.tf
+++ b/terraform/hmpps-engineering-jira-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-engineering-jira-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-engineering-jira-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-engineering-jira-installer.tf
+++ b/terraform/hmpps-engineering-jira-installer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-engineering-jira-installer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-engineering-jira-installer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-engineering-lambda-functions.tf
+++ b/terraform/hmpps-engineering-lambda-functions.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-engineering-lambda-functions" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-engineering-lambda-functions"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-engineering-operations.tf
+++ b/terraform/hmpps-engineering-operations.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-engineering-operations" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-engineering-operations"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-engineering-pipelines-utils.tf
+++ b/terraform/hmpps-engineering-pipelines-utils.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-engineering-pipelines-utils" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-engineering-pipelines-utils"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-engineering-pipelines.tf
+++ b/terraform/hmpps-engineering-pipelines.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-engineering-pipelines" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-engineering-pipelines"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-engineering-platform-terraform.tf
+++ b/terraform/hmpps-engineering-platform-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-engineering-platform-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-engineering-platform-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-engineering-tools.tf
+++ b/terraform/hmpps-engineering-tools.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-engineering-tools" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-engineering-tools"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-env-configs.tf
+++ b/terraform/hmpps-env-configs.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-env-configs" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-env-configs"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-logstash.tf
+++ b/terraform/hmpps-logstash.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-logstash" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-logstash"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-mis-terraform-repo-fsx.tf
+++ b/terraform/hmpps-mis-terraform-repo-fsx.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-mis-terraform-repo-fsx" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-mis-terraform-repo-fsx"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-mis-terraform-repo.tf
+++ b/terraform/hmpps-mis-terraform-repo.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-mis-terraform-repo" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-mis-terraform-repo"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-network-delius-new-tech-terraform.tf
+++ b/terraform/hmpps-network-delius-new-tech-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-network-delius-new-tech-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-network-delius-new-tech-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-network-terraform-alfresco.tf
+++ b/terraform/hmpps-network-terraform-alfresco.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-network-terraform-alfresco" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-network-terraform-alfresco"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-network-terraform-mis.tf
+++ b/terraform/hmpps-network-terraform-mis.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-network-terraform-mis" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-network-terraform-mis"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-nextcloud-installer.tf
+++ b/terraform/hmpps-nextcloud-installer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-nextcloud-installer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-nextcloud-installer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-nextcloud-packer.tf
+++ b/terraform/hmpps-nextcloud-packer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-nextcloud-packer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-nextcloud-packer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-nfs.tf
+++ b/terraform/hmpps-nfs.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-nfs" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-nfs"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-nomis-aws-terraform.tf
+++ b/terraform/hmpps-nomis-aws-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-nomis-aws-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-nomis-aws-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-nomis-bootstrap.tf
+++ b/terraform/hmpps-nomis-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-nomis-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-nomis-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-ops-alfresco-elasticsearch-bridge.tf
+++ b/terraform/hmpps-ops-alfresco-elasticsearch-bridge.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-ops-alfresco-elasticsearch-bridge" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-ops-alfresco-elasticsearch-bridge"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-oracle-database-autotasks.tf
+++ b/terraform/hmpps-oracle-database-autotasks.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-oracle-database-autotasks" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-oracle-database-autotasks"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-oracle-database-parameters.tf
+++ b/terraform/hmpps-oracle-database-parameters.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-oracle-database-parameters" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-oracle-database-parameters"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-oracle-database-patches.tf
+++ b/terraform/hmpps-oracle-database-patches.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-oracle-database-patches" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-oracle-database-patches"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-oracle-database.tf
+++ b/terraform/hmpps-oracle-database.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-oracle-database" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-oracle-database"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-pwm.tf
+++ b/terraform/hmpps-pwm.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-pwm" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-pwm"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-repo-security.tf
+++ b/terraform/hmpps-repo-security.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-repo-security" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-repo-security"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-security-access-terraform.tf
+++ b/terraform/hmpps-security-access-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-security-access-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-security-access-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-smtp-installer.tf
+++ b/terraform/hmpps-smtp-installer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-smtp-installer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-smtp-installer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-solr-bootstrap.tf
+++ b/terraform/hmpps-solr-bootstrap.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-solr-bootstrap" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-solr-bootstrap"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-solr-packer.tf
+++ b/terraform/hmpps-solr-packer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-solr-packer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-solr-packer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-spg-ansible.tf
+++ b/terraform/hmpps-spg-ansible.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-spg-ansible" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-spg-ansible"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-spg-renderer.tf
+++ b/terraform/hmpps-spg-renderer.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-spg-renderer" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-spg-renderer"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-spg.tf
+++ b/terraform/hmpps-spg.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-spg" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-spg"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-terraform-modules.tf
+++ b/terraform/hmpps-terraform-modules.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-terraform-modules" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-terraform-modules"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-vagrant-repo.tf
+++ b/terraform/hmpps-vagrant-repo.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-vagrant-repo" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-vagrant-repo"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-vcms-infra-versions.tf
+++ b/terraform/hmpps-vcms-infra-versions.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-vcms-infra-versions" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-vcms-infra-versions"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-vcms-terraform.tf
+++ b/terraform/hmpps-vcms-terraform.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-vcms-terraform" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-vcms-terraform"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-vcms.tf
+++ b/terraform/hmpps-vcms.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-vcms" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-vcms"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/hmpps-windows-2019-cis.tf
+++ b/terraform/hmpps-windows-2019-cis.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "hmpps-windows-2019-cis" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "hmpps-windows-2019-cis"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/jira-service-management-test-automation.tf
+++ b/terraform/jira-service-management-test-automation.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "jira-service-management-test-automation" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "jira-service-management-test-automation"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/jitbit-test-automation.tf
+++ b/terraform/jitbit-test-automation.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "jitbit-test-automation" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "jitbit-test-automation"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/mis-performance-test.tf
+++ b/terraform/mis-performance-test.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "mis-performance-test" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "mis-performance-test"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/mis-test-automation.tf
+++ b/terraform/mis-test-automation.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "mis-test-automation" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "mis-test-automation"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/ndelius-api.tf
+++ b/terraform/ndelius-api.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "ndelius-api" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "ndelius-api"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/ndelius-gatling-performance-tests.tf
+++ b/terraform/ndelius-gatling-performance-tests.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "ndelius-gatling-performance-tests" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "ndelius-gatling-performance-tests"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/ndelius-new-tech.tf
+++ b/terraform/ndelius-new-tech.tf
@@ -1,20 +1,10 @@
-module "hmpps-cporacle-application" {
+module "ndelius-new-tech" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "ndelius-new-tech"
   collaborators = [
     {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
-    {
       github_user  = "swestb"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Stuart Westbrook"                                                                                                                      #  The name of the person behind github_user
       email        = "stuart.westbrook@adrocgroup.com"                                                                                                       #  Their email address
       org          = "Adroc Group"                                                                                                                           #  The organisation/entity they belong to

--- a/terraform/ndelius-serenity-automation.tf
+++ b/terraform/ndelius-serenity-automation.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "ndelius-serenity-automation" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "ndelius-serenity-automation"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/ndelius-test-automation.tf
+++ b/terraform/ndelius-test-automation.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "ndelius-test-automation" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "ndelius-test-automation"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/ndelius-um.tf
+++ b/terraform/ndelius-um.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "ndelius-um" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "ndelius-um"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/vcms-manual-deployments.tf
+++ b/terraform/vcms-manual-deployments.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "vcms-manual-deployments" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "vcms-manual-deployments"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/vcms-perf-test.tf
+++ b/terraform/vcms-perf-test.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "vcms-perf-test" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "vcms-perf-test"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/vcms-performance-tests.tf
+++ b/terraform/vcms-performance-tests.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "vcms-performance-tests" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "vcms-performance-tests"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/vcms-test-automation.tf
+++ b/terraform/vcms-test-automation.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "vcms-test-automation" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "vcms-test-automation"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"

--- a/terraform/vcms.tf
+++ b/terraform/vcms.tf
@@ -1,17 +1,7 @@
-module "hmpps-cporacle-application" {
+module "vcms" {
   source     = "./modules/repository-collaborators"
-  repository = "hmpps-cporacle-application"
+  repository = "vcms"
   collaborators = [
-    {
-      github_user  = "aliuk2012"
-      permission   = "push"
-      name         = "Alistair Laing"                                                                                               #  The name of the person behind github_user
-      email        = "alistair.laing@adrocgroup.com"                                                                                #  Their email address
-      org          = "Adroc Group"                                                                                                  #  The organisation/entity they belong to
-      reason       = "Alistair needs access so that he can develop required code in CP Oracle to support urgent Day 1 deliverables" #  Why is this person being granted access?
-      added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"                                     #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2021-06-21"                                                                                                   #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
     {
       github_user  = "swestb"
       permission   = "admin"


### PR DESCRIPTION
Resolves #182.

Since you can't add collaborators to a team, I've copied the `hmpps-jenkins-admin` permission levels to add @swestb to all of the same repositories.