### PR TITLE
Change permission from `write` to `push`

### DIFF
--- a/terraform/curious-API.tf
+++ b/terraform/curious-API.tf
@@ -4,7 +4,7 @@ module "curious-API" {
   collaborators = [
     {
       github_user  = "graadi"
-      permission   = "write"
+      permission   = "push"
       name         = "Adrian Gramada"
       email        = "adrian.gramada@meganexus.com"
       org          = "MegaNexus"


### PR DESCRIPTION
Changing permission from write to push as write is not a valid variable accepted by the Github API.