### PR TITLE
Add repo transit-gateways and assign Stuart push access

### DIFF
--- a/terraform/transit-gateways.tf
+++ b/terraform/transit-gateways.tf
@@ -1,0 +1,16 @@
+module "transit-gateways" {
+  source     = "./modules/repository-collaborators"
+  repository = "transit-gateways"
+  collaborators = [
+    {
+      github_user  = "swestb"
+      permission   = "push"  #  pull|push|admin
+      name         = "Stuart Westbrook"  #  The name of the person behind github_user
+      email        = "stuart.westbrook@adrocgroup.com"  #  Their email address
+      org          = "adroc group."  #  The organisation/entity they belong to
+      reason       = "To help connect Deluis to its required components in North Bridge via transit gateway"  #  Why is this person being granted access?
+      added_by     = "Richard.Baguley@digital.justice.gov.uk"  #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
+      review_after = "2022-02-09"  #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+    },
+  ]
+}

--- a/terraform/transit-gateways.tf
+++ b/terraform/transit-gateways.tf
@@ -4,13 +4,13 @@ module "transit-gateways" {
   collaborators = [
     {
       github_user  = "swestb"
-      permission   = "push"  #  pull|push|admin
-      name         = "Stuart Westbrook"  #  The name of the person behind github_user
-      email        = "stuart.westbrook@adrocgroup.com"  #  Their email address
-      org          = "adroc group."  #  The organisation/entity they belong to
-      reason       = "To help connect Deluis to its required components in North Bridge via transit gateway"  #  Why is this person being granted access?
-      added_by     = "Richard.Baguley@digital.justice.gov.uk"  #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2022-02-09"  #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      permission   = "push"                                                                                  #  pull|push|admin
+      name         = "Stuart Westbrook"                                                                      #  The name of the person behind github_user
+      email        = "stuart.westbrook@adrocgroup.com"                                                       #  Their email address
+      org          = "adroc group."                                                                          #  The organisation/entity they belong to
+      reason       = "To help connect Deluis to its required components in North Bridge via transit gateway" #  Why is this person being granted access?
+      added_by     = "Richard.Baguley@digital.justice.gov.uk"                                                #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
+      review_after = "2022-02-09"                                                                            #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
     },
   ]
 }


### PR DESCRIPTION
This is to enable Delius support access to create transit gw attachments/resource access management.