### PR TITLE
Remove expired collaborator from Terraform file/s for VasilDimitrov22

### DIFF
--- a/terraform/yjaf-pnomis.tf
+++ b/terraform/yjaf-pnomis.tf
@@ -13,16 +13,6 @@ module "yjaf-pnomis" {
       review_after = "2022-12-13"
     },
     {
-      github_user  = "VasilDimitrov22"
-      permission   = "push"
-      name         = "Vasil Dimitrov"
-      email        = "vasil.dimitrov@necsws.com"
-      org          = "NEC Software Solutions"
-      reason       = "dev needs access to make app changes"
-      added_by     = "Joanna Harvey <joanna.harvey@necsws.com>"
-      review_after = "2022-08-04"
-    },
-    {
       github_user  = "ttipler"
       permission   = "admin"
       name         = "Thomas Tipler"


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator VasilDimitrov22 review date has expired for the file/s contained in this pull request.

Either approve this pull request, modify it or delete it if it is no longer necessary.
