### PR TITLE
Add full Org member / collaborator to Terraform file/s for simoncreasy-civica

### DIFF
--- a/terraform/hmpps-vcms-terraform.tf
+++ b/terraform/hmpps-vcms-terraform.tf
@@ -2,6 +2,15 @@ module "hmpps-vcms-terraform" {
   source     = "./modules/repository-collaborators"
   repository = "hmpps-vcms-terraform"
   collaborators = [
-
+    {
+      github_user  = "simoncreasy-civica"
+      permission   = ""
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-15"
+    },
   ]
 }


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

simoncreasy-civica was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because Terraform requires the collaborators repository permission.

Permission can either be admin, push, maintain, pull or triage.

