### PR TITLE
Add full Org member / collaborator to Terraform file/s for miriamgo-civica

### DIFF
--- a/terraform/hmpps-vcms-infra-versions.tf
+++ b/terraform/hmpps-vcms-infra-versions.tf
@@ -3,24 +3,14 @@ module "hmpps-vcms-infra-versions" {
   repository = "hmpps-vcms-infra-versions"
   collaborators = [
     {
-      github_user  = "simoncreasy-civica"
-      permission   = "push"
-      name         = "Simon Creasy"                                                                      #  The name of the person behind github_user
-      email        = "simon.creasy@civica.co.uk"                                                         #  Their email address
-      org          = "Civica"                                                                            #  The organisation/entity they belong to
-      reason       = "Civica developer that helps the development of the Victims Case Management System" #  Why is this person being granted access?
-      added_by     = "Probation WebOps team, probation-webops@digital.justice.gov.uk"                    #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2022-11-21"                                                                        #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    },
-    {
-      github_user  = "sim-barnes"
-      permission   = "push"
-      name         = "Simon Barnes"                                                   #  The name of the person behind github_user
-      email        = "simon.barnes@civica.co.uk"                                      #  Their email address
-      org          = "Civica"                                                         #  The organisation/entity they belong to
-      reason       = "Civica developer for Victims Case Management System"            #  Why is this person being granted access?
-      added_by     = "Probation WebOps team, probation-webops@digital.justice.gov.uk" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2022-11-21"                                                     #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      github_user  = "miriamgo-civica"
+      permission   = ""
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-15"
     },
   ]
 }

--- a/terraform/hmpps-vcms-terraform.tf
+++ b/terraform/hmpps-vcms-terraform.tf
@@ -2,6 +2,15 @@ module "hmpps-vcms-terraform" {
   source     = "./modules/repository-collaborators"
   repository = "hmpps-vcms-terraform"
   collaborators = [
-
+    {
+      github_user  = "miriamgo-civica"
+      permission   = ""
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-15"
+    },
   ]
 }


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

miriamgo-civica was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because Terraform requires the collaborators repository permission.

Permission can either be admin, push, maintain, pull or triage.

