### PR TITLE
Add full Org member / collaborator to Terraform file/s for emileswarts

### DIFF
--- a/terraform/PaloAlto-pipelines.tf
+++ b/terraform/PaloAlto-pipelines.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "PaloAlto-pipelines" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "PaloAlto-pipelines"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/aws-ta-testing.tf
+++ b/terraform/aws-ta-testing.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "aws-ta-testing" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "aws-ta-testing"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/aws-trusted-advisor-to-github-issues.tf
+++ b/terraform/aws-trusted-advisor-to-github-issues.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "aws-trusted-advisor-to-github-issues" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "aws-trusted-advisor-to-github-issues"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/cloud-operations-slack-bot.tf
+++ b/terraform/cloud-operations-slack-bot.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "cloud-operations-slack-bot" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "cloud-operations-slack-bot"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/deployment-GlobalProtect-ASG.tf
+++ b/terraform/deployment-GlobalProtect-ASG.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "deployment-GlobalProtect-ASG" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "deployment-GlobalProtect-ASG"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/deployment-PSN-Access.tf
+++ b/terraform/deployment-PSN-Access.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "deployment-PSN-Access" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "deployment-PSN-Access"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/deployment-SOP-OCI-Access.tf
+++ b/terraform/deployment-SOP-OCI-Access.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "deployment-SOP-OCI-Access" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "deployment-SOP-OCI-Access"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/deployment-aws-noc.tf
+++ b/terraform/deployment-aws-noc.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "deployment-aws-noc" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "deployment-aws-noc"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/deployment-panorama.tf
+++ b/terraform/deployment-panorama.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "deployment-panorama" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "deployment-panorama"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/deployment-tgw.tf
+++ b/terraform/deployment-tgw.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "deployment-tgw" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "deployment-tgw"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/mojo-aws-github-oidc-provider.tf
+++ b/terraform/mojo-aws-github-oidc-provider.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "mojo-aws-github-oidc-provider" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "mojo-aws-github-oidc-provider"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/nvvs-devops-github-actions.tf
+++ b/terraform/nvvs-devops-github-actions.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "nvvs-devops-github-actions" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "nvvs-devops-github-actions"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/nvvs-devops-monitor.tf
+++ b/terraform/nvvs-devops-monitor.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "nvvs-devops-monitor" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "nvvs-devops-monitor"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/nvvs-devops.tf
+++ b/terraform/nvvs-devops.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "nvvs-devops" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "nvvs-devops"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-device-dhcp-server.tf
+++ b/terraform/staff-device-dhcp-server.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-device-dhcp-server" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-device-dhcp-server"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-device-dns-dhcp-admin.tf
+++ b/terraform/staff-device-dns-dhcp-admin.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-device-dns-dhcp-admin" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-device-dns-dhcp-admin"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-device-dns-dhcp-disaster-recovery.tf
+++ b/terraform/staff-device-dns-dhcp-disaster-recovery.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-device-dns-dhcp-disaster-recovery" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-device-dns-dhcp-disaster-recovery"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-device-dns-dhcp-infrastructure.tf
+++ b/terraform/staff-device-dns-dhcp-infrastructure.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-device-dns-dhcp-infrastructure" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-device-dns-dhcp-infrastructure"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-device-dns-server.tf
+++ b/terraform/staff-device-dns-server.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-device-dns-server" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-device-dns-server"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-device-docker-base-images.tf
+++ b/terraform/staff-device-docker-base-images.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-device-docker-base-images" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-device-docker-base-images"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-device-logging-dns-dhcp-integration-tests.tf
+++ b/terraform/staff-device-logging-dns-dhcp-integration-tests.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-device-logging-dns-dhcp-integration-tests" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-device-logging-dns-dhcp-integration-tests"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-device-logging-infrastructure.tf
+++ b/terraform/staff-device-logging-infrastructure.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-device-logging-infrastructure" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-device-logging-infrastructure"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-device-logging-syslog-to-cloudwatch.tf
+++ b/terraform/staff-device-logging-syslog-to-cloudwatch.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-device-logging-syslog-to-cloudwatch" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-device-logging-syslog-to-cloudwatch"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-device-management-intune-scripts.tf
+++ b/terraform/staff-device-management-intune-scripts.tf
@@ -5,22 +5,32 @@ module "staff-device-management-intune-scripts" {
     {
       github_user  = "JazJax"
       permission   = "admin"
-      name         = "Jasper Jackson"                #  The name of the person behind github_user
-      email        = "jasper.jackson@madetech.com"   #  Their email address
-      org          = "MadeTech"                      #  The organisation/entity they belong to
-      reason       = "VICTOR product development"    #  Why is this person being granted access?
-      added_by     = "matthew.white1@justice.gov.uk" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2022-12-31"                    #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Jasper Jackson"
+      email        = "jasper.jackson@madetech.com"
+      org          = "MadeTech"
+      reason       = "VICTOR product development"
+      added_by     = "matthew.white1@justice.gov.uk"
+      review_after = "2022-12-31"
     },
     {
       github_user  = "BingliuMT"
       permission   = "admin"
-      name         = "Bingjie Liu"                   #  The name of the person behind github_user
-      email        = "bingjie.liu@madetech.com"      #  Their email address
-      org          = "MadeTech"                      #  The organisation/entity they belong to
-      reason       = "VICTOR product development"    #  Why is this person being granted access?
-      added_by     = "matthew.white1@justice.gov.uk" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2022-12-31"                    #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
-    }
+      name         = "Bingjie Liu"
+      email        = "bingjie.liu@madetech.com"
+      org          = "MadeTech"
+      reason       = "VICTOR product development"
+      added_by     = "matthew.white1@justice.gov.uk"
+      review_after = "2022-12-31"
+    },
+    {
+      github_user  = "emileswarts"
+      permission   = ""
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-16"
+    },
   ]
 }

--- a/terraform/staff-device-private-dns-zone.tf
+++ b/terraform/staff-device-private-dns-zone.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-device-private-dns-zone" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-device-private-dns-zone"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-external-dynamic-list.tf
+++ b/terraform/staff-external-dynamic-list.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-external-dynamic-list" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-external-dynamic-list"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-admin-sso.tf
+++ b/terraform/staff-infrastructure-admin-sso.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-admin-sso" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-admin-sso"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-certificate-services.tf
+++ b/terraform/staff-infrastructure-certificate-services.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-certificate-services" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-certificate-services"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-metric-aggregation-server.tf
+++ b/terraform/staff-infrastructure-metric-aggregation-server.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-metric-aggregation-server" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-metric-aggregation-server"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-metric-aggregator-cloud.tf
+++ b/terraform/staff-infrastructure-metric-aggregator-cloud.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-metric-aggregator-cloud" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-metric-aggregator-cloud"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-monitoring-app-reachability.tf
+++ b/terraform/staff-infrastructure-monitoring-app-reachability.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-monitoring-app-reachability" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-monitoring-app-reachability"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-monitoring-blackbox-exporter.tf
+++ b/terraform/staff-infrastructure-monitoring-blackbox-exporter.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-monitoring-blackbox-exporter" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-monitoring-blackbox-exporter"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-monitoring-config.tf
+++ b/terraform/staff-infrastructure-monitoring-config.tf
@@ -3,34 +3,14 @@ module "staff-infrastructure-monitoring-config" {
   repository = "staff-infrastructure-monitoring-config"
   collaborators = [
     {
-      github_user  = "yusufsheiqh"
-      permission   = "admin"
-      name         = "Yusuf Sheikh"
-      email        = "yusuf@madetech.com"
-      org          = "Made Tech Ltd"
-      reason       = "MoJ NAC Tech Team"
-      added_by     = "justin.fielding@justice.gov.uk"
-      review_after = "2022-01-01"
+      github_user  = "emileswarts"
+      permission   = ""
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-16"
     },
-    {
-      github_user  = "C-gyorfi"
-      permission   = "admin"
-      name         = "Csaba Gyorfi"
-      email        = "csaba@madetech.com"
-      org          = "Made Tech Ltd"
-      reason       = "MoJ NAC Tech Team"
-      added_by     = "justin.fielding@justice.gov.uk"
-      review_after = "2022-01-01"
-    },
-    {
-      github_user  = "MichaelCullenMadeTech"
-      permission   = "admin"
-      name         = "Michael Cullen"
-      email        = "michael.cullen@madetech.com"
-      org          = "Made Tech Ltd"
-      reason       = "MoJ NAC Tech Team"
-      added_by     = "justin.fielding@justice.gov.uk"
-      review_after = "2022-01-01"
-    }
   ]
 }

--- a/terraform/staff-infrastructure-monitoring-deployments.tf
+++ b/terraform/staff-infrastructure-monitoring-deployments.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-monitoring-deployments" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-monitoring-deployments"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-monitoring-dns-reachability.tf
+++ b/terraform/staff-infrastructure-monitoring-dns-reachability.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-monitoring-dns-reachability" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-monitoring-dns-reachability"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-monitoring-snmpexporter.tf
+++ b/terraform/staff-infrastructure-monitoring-snmpexporter.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-monitoring-snmpexporter" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-monitoring-snmpexporter"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-monitoring.tf
+++ b/terraform/staff-infrastructure-monitoring.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-monitoring" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-monitoring"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-network-operations.tf
+++ b/terraform/staff-infrastructure-network-operations.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-network-operations" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-network-operations"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-network-services.tf
+++ b/terraform/staff-infrastructure-network-services.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-network-services" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-network-services"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff-infrastructure-smtp-relay-server.tf
+++ b/terraform/staff-infrastructure-smtp-relay-server.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff-infrastructure-smtp-relay-server" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff-infrastructure-smtp-relay-server"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/staff.tf
+++ b/terraform/staff.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "staff" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "staff"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/technology-services.tf
+++ b/terraform/technology-services.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "technology-services" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "technology-services"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/terraform-aws-panorama.tf
+++ b/terraform/terraform-aws-panorama.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "terraform-aws-panorama" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "terraform-aws-panorama"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/terraform-aws-tgw.tf
+++ b/terraform/terraform-aws-tgw.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "terraform-aws-tgw" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "terraform-aws-tgw"
   collaborators = [
     {
       github_user  = "emileswarts"

--- a/terraform/terraform-panorama-config.tf
+++ b/terraform/terraform-panorama-config.tf
@@ -5,12 +5,22 @@ module "terraform-panorama-config" {
     {
       github_user  = "nmatveev"
       permission   = "push"
-      name         = "Nikolay Matveev"                        #  The name of the person behind github_user
-      email        = "nmatveev@paloaltonetworks.com"          #  Their email address
-      org          = "Palo Alto"                              #  The organisation/entity they belong to
-      reason       = "TechOps Management of Panorama"         #  Why is this person being granted access?
-      added_by     = "MoJ-TechnicalOperations@justice.gov.uk" #  Who made the decision to grant them access? e.g. 'Awesome Team <awesome.team@digital.justice.gov.uk>'
-      review_after = "2022-03-31"                             #  Date after which this grant should be reviewed/revoked, e.g. 2021-11-26
+      name         = "Nikolay Matveev"
+      email        = "nmatveev@paloaltonetworks.com"
+      org          = "Palo Alto"
+      reason       = "TechOps Management of Panorama"
+      added_by     = "MoJ-TechnicalOperations@justice.gov.uk"
+      review_after = "2022-03-31"
+    },
+    {
+      github_user  = "emileswarts"
+      permission   = ""
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-16"
     },
   ]
 }

--- a/terraform/transit-gateways.tf
+++ b/terraform/transit-gateways.tf
@@ -1,6 +1,6 @@
-module "staff-device-shared-services-infrastructure" {
+module "transit-gateways" {
   source     = "./modules/repository-collaborators"
-  repository = "staff-device-shared-services-infrastructure"
+  repository = "transit-gateways"
   collaborators = [
     {
       github_user  = "emileswarts"


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

emileswarts was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because Terraform requires the collaborators repository permission.

Permission can either be admin, push, maintain, pull or triage.

