### PR TITLE
Remove expired collaborator from Terraform file/s for helenvickers-roc

### DIFF
--- a/terraform/modernisation-platform-environments.tf
+++ b/terraform/modernisation-platform-environments.tf
@@ -73,16 +73,6 @@ module "modernisation-platform-environments" {
       review_after = "2022-11-01"
     },
     {
-      github_user  = "helenvickers-roc"
-      permission   = "push"
-      name         = "Helen Vickers"
-      email        = "Helen.Vickers@roctechnologies.com"
-      org          = "Roc Technologies"
-      reason       = "Roc have built and are supporting the HMPPS Equip application on the Modernisation Platform"
-      added_by     = "Modernisation Platform team, modernisation-platform@digital.justice.gov.uk"
-      review_after = "2022-11-01"
-    },
-    {
       github_user  = "Tom-Whi"
       permission   = "push"
       name         = "Tom Whiteley"
@@ -131,6 +121,6 @@ module "modernisation-platform-environments" {
       reason       = "Get access to PPUD on Modernisation Platform"
       added_by     = "Modernisation Platform team, modernisation-platform@digital.justice.gov.uk"
       review_after = "2023-11-04"
-    }
+    },
   ]
 }


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator helenvickers-roc review date has expired for the file/s contained in this pull request.

Either approve this pull request, modify it or delete it if it is no longer necessary.
