### PR TITLE
Remove expired collaborator from Terraform file/s for hullcoastie

### DIFF
--- a/terraform/modernisation-platform-environments.tf
+++ b/terraform/modernisation-platform-environments.tf
@@ -3,16 +3,6 @@ module "modernisation-platform-environments" {
   repository = "modernisation-platform-environments"
   collaborators = [
     {
-      github_user  = "hullcoastie"
-      permission   = "push"
-      name         = "John Broom"
-      email        = "John.Broom@roctechnologies.com"
-      org          = "Roc Technologies"
-      reason       = "Roc have built and are supporting the HMPPS Equip application on the Modernisation Platform"
-      added_by     = "Modernisation Platform team, modernisation-platform@digital.justice.gov.uk"
-      review_after = "2022-11-01"
-    },
-    {
       github_user  = "jamesashton-roc"
       permission   = "push"
       name         = "James Ashton"
@@ -131,6 +121,6 @@ module "modernisation-platform-environments" {
       reason       = "Get access to PPUD on Modernisation Platform"
       added_by     = "Modernisation Platform team, modernisation-platform@digital.justice.gov.uk"
       review_after = "2023-11-04"
-    }
+    },
   ]
 }


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator hullcoastie review date has expired for the file/s contained in this pull request.

Either approve this pull request, modify it or delete it if it is no longer necessary.
