### PR TITLE
Modify permission in Terraform file/s for tomvaughan77

### DIFF
--- a/terraform/bichard7-next-ui.tf
+++ b/terraform/bichard7-next-ui.tf
@@ -74,7 +74,7 @@ module "bichard7-next-ui" {
     },
     {
       github_user  = "tomvaughan77"
-      permission   = "push"
+      permission   = "admin"
       name         = "Tom Vaughan"
       email        = "tom.vaughan@madetech.com"
       org          = "Madetech"
@@ -101,6 +101,6 @@ module "bichard7-next-ui" {
       reason       = "CJSE Bichard Development"
       added_by     = "Dom Tomkins <dom.tomkins@justice.gov.uk>"
       review_after = "2022-12-31"
-    }
+    },
   ]
 }


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator tomvaughan77 permission on Github is different to the permission in the Terraform file for the repository.

This is because the collaborator is a full organization member, is able to join repositories outside of Terraform and may have different access to the repository now they are in a Team.

The permission on Github is given the priority.

This pull request ensures we keep track of those collaborators, which repositories they are accessing and their permission.

Permission can either be admin, push, maintain, pull or triage.

