### PR TITLE
Modify permission in Terraform file/s for miriamgo-civica

### DIFF
--- a/terraform/hmpps-domestic-abuse-support-officers.tf
+++ b/terraform/hmpps-domestic-abuse-support-officers.tf
@@ -14,7 +14,7 @@ module "hmpps-domestic-abuse-support-officers" {
     },
     {
       github_user  = "miriamgo-civica"
-      permission   = "maintain"
+      permission   = "push"
       name         = "Miriam Gomez-Orozco"
       email        = "Miriam.Gomez-Orozco@civica.co.uk"
       org          = "Civica"

--- a/terraform/hmpps-vcms-app-cp.tf
+++ b/terraform/hmpps-vcms-app-cp.tf
@@ -24,7 +24,7 @@ module "hmpps-vcms-app-cp" {
     },
     {
       github_user  = "miriamgo-civica"
-      permission   = "push"
+      permission   = "maintain"
       name         = "Miriam Gomez-Orozco"
       email        = "Miriam.Gomez-Orozco@civica.co.uk"
       org          = "civica"

--- a/terraform/hmpps-vcms.tf
+++ b/terraform/hmpps-vcms.tf
@@ -14,7 +14,7 @@ module "hmpps-vcms" {
     },
     {
       github_user  = "miriamgo-civica"
-      permission   = "maintain"
+      permission   = "push"
       name         = "Miriam Gomez-Orozco"
       email        = "Miriam.Gomez-Orozco@civica.co.uk"
       org          = "Civica"


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator miriamgo-civica permission on Github is different to the permission in the Terraform file for the repository.

This is because the collaborator is a full organization member, is able to join repositories outside of Terraform and may have different access to the repository now they are in a Team.

The permission on Github is given the priority.

This pull request ensures we keep track of those collaborators, which repositories they are accessing and their permission.

Permission can either be admin, push, maintain, pull or triage.

