### PR TITLE
Add full Org member / collaborator to Terraform file/s for emileswarts

### DIFF
--- a/terraform/PaloAlto-pipelines.tf
+++ b/terraform/PaloAlto-pipelines.tf
@@ -1,0 +1,16 @@
+module "PaloAlto-pipelines" {
+  source     = "./modules/repository-collaborators"
+  repository = "PaloAlto-pipelines"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/aws-ta-testing.tf
+++ b/terraform/aws-ta-testing.tf
@@ -1,0 +1,16 @@
+module "aws-ta-testing" {
+  source     = "./modules/repository-collaborators"
+  repository = "aws-ta-testing"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/aws-trusted-advisor-to-github-issues.tf
+++ b/terraform/aws-trusted-advisor-to-github-issues.tf
@@ -1,0 +1,16 @@
+module "aws-trusted-advisor-to-github-issues" {
+  source     = "./modules/repository-collaborators"
+  repository = "aws-trusted-advisor-to-github-issues"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/deployment-GlobalProtect-ASG.tf
+++ b/terraform/deployment-GlobalProtect-ASG.tf
@@ -1,0 +1,16 @@
+module "deployment-GlobalProtect-ASG" {
+  source     = "./modules/repository-collaborators"
+  repository = "deployment-GlobalProtect-ASG"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/deployment-PSN-Access.tf
+++ b/terraform/deployment-PSN-Access.tf
@@ -1,0 +1,16 @@
+module "deployment-PSN-Access" {
+  source     = "./modules/repository-collaborators"
+  repository = "deployment-PSN-Access"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/deployment-SOP-OCI-Access.tf
+++ b/terraform/deployment-SOP-OCI-Access.tf
@@ -1,0 +1,16 @@
+module "deployment-SOP-OCI-Access" {
+  source     = "./modules/repository-collaborators"
+  repository = "deployment-SOP-OCI-Access"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/deployment-aws-noc.tf
+++ b/terraform/deployment-aws-noc.tf
@@ -1,0 +1,16 @@
+module "deployment-aws-noc" {
+  source     = "./modules/repository-collaborators"
+  repository = "deployment-aws-noc"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/deployment-panorama.tf
+++ b/terraform/deployment-panorama.tf
@@ -1,0 +1,16 @@
+module "deployment-panorama" {
+  source     = "./modules/repository-collaborators"
+  repository = "deployment-panorama"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/deployment-tgw.tf
+++ b/terraform/deployment-tgw.tf
@@ -1,0 +1,16 @@
+module "deployment-tgw" {
+  source     = "./modules/repository-collaborators"
+  repository = "deployment-tgw"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-device-dhcp-server.tf
+++ b/terraform/staff-device-dhcp-server.tf
@@ -1,0 +1,16 @@
+module "staff-device-dhcp-server" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-device-dhcp-server"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-device-dns-dhcp-admin.tf
+++ b/terraform/staff-device-dns-dhcp-admin.tf
@@ -1,0 +1,16 @@
+module "staff-device-dns-dhcp-admin" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-device-dns-dhcp-admin"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-device-dns-dhcp-disaster-recovery.tf
+++ b/terraform/staff-device-dns-dhcp-disaster-recovery.tf
@@ -1,0 +1,16 @@
+module "staff-device-dns-dhcp-disaster-recovery" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-device-dns-dhcp-disaster-recovery"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-device-dns-dhcp-infrastructure.tf
+++ b/terraform/staff-device-dns-dhcp-infrastructure.tf
@@ -1,0 +1,16 @@
+module "staff-device-dns-dhcp-infrastructure" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-device-dns-dhcp-infrastructure"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-device-dns-server.tf
+++ b/terraform/staff-device-dns-server.tf
@@ -1,0 +1,16 @@
+module "staff-device-dns-server" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-device-dns-server"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-device-docker-base-images.tf
+++ b/terraform/staff-device-docker-base-images.tf
@@ -1,0 +1,16 @@
+module "staff-device-docker-base-images" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-device-docker-base-images"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-device-logging-infrastructure.tf
+++ b/terraform/staff-device-logging-infrastructure.tf
@@ -1,0 +1,16 @@
+module "staff-device-logging-infrastructure" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-device-logging-infrastructure"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-device-logging-syslog-to-cloudwatch.tf
+++ b/terraform/staff-device-logging-syslog-to-cloudwatch.tf
@@ -1,0 +1,16 @@
+module "staff-device-logging-syslog-to-cloudwatch" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-device-logging-syslog-to-cloudwatch"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-device-management-intune-scripts.tf
+++ b/terraform/staff-device-management-intune-scripts.tf
@@ -21,6 +21,16 @@ module "staff-device-management-intune-scripts" {
       reason       = "VICTOR product development"
       added_by     = "matthew.white1@justice.gov.uk"
       review_after = "2022-12-31"
-    }
+    },
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
   ]
 }

--- a/terraform/staff-device-private-dns-zone.tf
+++ b/terraform/staff-device-private-dns-zone.tf
@@ -1,0 +1,16 @@
+module "staff-device-private-dns-zone" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-device-private-dns-zone"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-device-shared-services-infrastructure.tf
+++ b/terraform/staff-device-shared-services-infrastructure.tf
@@ -31,6 +31,16 @@ module "staff-device-shared-services-infrastructure" {
       reason       = "MoJ Network Access Control Tech Team"
       added_by     = "justin.fielding@justice.gov.uk"
       review_after = "2022-01-01"
-    }
+    },
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
   ]
 }

--- a/terraform/staff-external-dynamic-list.tf
+++ b/terraform/staff-external-dynamic-list.tf
@@ -1,0 +1,16 @@
+module "staff-external-dynamic-list" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-external-dynamic-list"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-certificate-services.tf
+++ b/terraform/staff-infrastructure-certificate-services.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-certificate-services" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-certificate-services"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-metric-aggregation-server.tf
+++ b/terraform/staff-infrastructure-metric-aggregation-server.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-metric-aggregation-server" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-metric-aggregation-server"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-metric-aggregator-cloud.tf
+++ b/terraform/staff-infrastructure-metric-aggregator-cloud.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-metric-aggregator-cloud" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-metric-aggregator-cloud"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-monitoring-app-reachability.tf
+++ b/terraform/staff-infrastructure-monitoring-app-reachability.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-monitoring-app-reachability" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-monitoring-app-reachability"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-monitoring-blackbox-exporter.tf
+++ b/terraform/staff-infrastructure-monitoring-blackbox-exporter.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-monitoring-blackbox-exporter" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-monitoring-blackbox-exporter"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-monitoring-config.tf
+++ b/terraform/staff-infrastructure-monitoring-config.tf
@@ -31,6 +31,16 @@ module "staff-infrastructure-monitoring-config" {
       reason       = "MoJ NAC Tech Team"
       added_by     = "justin.fielding@justice.gov.uk"
       review_after = "2022-01-01"
-    }
+    },
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
   ]
 }

--- a/terraform/staff-infrastructure-monitoring-deployments.tf
+++ b/terraform/staff-infrastructure-monitoring-deployments.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-monitoring-deployments" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-monitoring-deployments"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-monitoring-dns-reachability.tf
+++ b/terraform/staff-infrastructure-monitoring-dns-reachability.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-monitoring-dns-reachability" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-monitoring-dns-reachability"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-monitoring-snmpexporter.tf
+++ b/terraform/staff-infrastructure-monitoring-snmpexporter.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-monitoring-snmpexporter" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-monitoring-snmpexporter"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-monitoring.tf
+++ b/terraform/staff-infrastructure-monitoring.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-monitoring" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-monitoring"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-network-operations.tf
+++ b/terraform/staff-infrastructure-network-operations.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-network-operations" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-network-operations"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-network-services.tf
+++ b/terraform/staff-infrastructure-network-services.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-network-services" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-network-services"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff-infrastructure-smtp-relay-server.tf
+++ b/terraform/staff-infrastructure-smtp-relay-server.tf
@@ -1,0 +1,16 @@
+module "staff-infrastructure-smtp-relay-server" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff-infrastructure-smtp-relay-server"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/staff.tf
+++ b/terraform/staff.tf
@@ -1,0 +1,16 @@
+module "staff" {
+  source     = "./modules/repository-collaborators"
+  repository = "staff"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/technology-services.tf
+++ b/terraform/technology-services.tf
@@ -1,0 +1,16 @@
+module "technology-services" {
+  source     = "./modules/repository-collaborators"
+  repository = "technology-services"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/terraform-aws-panorama.tf
+++ b/terraform/terraform-aws-panorama.tf
@@ -1,0 +1,16 @@
+module "terraform-aws-panorama" {
+  source     = "./modules/repository-collaborators"
+  repository = "terraform-aws-panorama"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/terraform-aws-tgw.tf
+++ b/terraform/terraform-aws-tgw.tf
@@ -1,0 +1,16 @@
+module "terraform-aws-tgw" {
+  source     = "./modules/repository-collaborators"
+  repository = "terraform-aws-tgw"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}

--- a/terraform/terraform-panorama-config.tf
+++ b/terraform/terraform-panorama-config.tf
@@ -12,5 +12,15 @@ module "terraform-panorama-config" {
       added_by     = "MoJ-TechnicalOperations@justice.gov.uk"
       review_after = "2022-03-31"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
   ]
 }

--- a/terraform/transit-gateways.tf
+++ b/terraform/transit-gateways.tf
@@ -1,0 +1,16 @@
+module "transit-gateways" {
+  source     = "./modules/repository-collaborators"
+  repository = "transit-gateways"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = ""
+      email        = ""
+      org          = ""
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-19"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator emileswarts was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

