### PR TITLE
Remove expired collaborator from Terraform file/s for johngriffin

### DIFF
--- a/terraform/delius.tf
+++ b/terraform/delius.tf
@@ -2,15 +2,5 @@ module "delius" {
   source     = "./modules/repository-collaborators"
   repository = "delius"
   collaborators = [
-    {
-      github_user  = "johngriffin"
-      permission   = "pull"
-      name         = "John Griffin"
-      email        = "john.griffin@digital.justice.gov.uk"
-      org          = "Create Change"
-      reason       = "AI Architect working on Making Recall Decisions"
-      added_by     = "Duncan Crawford on behalf of Making Recall Decision team, Duncan.Crawford@digital.justice.gov.uk"
-      review_after = "2021-12-31"
-    },
   ]
 }


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator johngriffin review date has expired for the file/s contained in this pull request.

Either approve this pull request, modify it or delete it if it is no longer necessary.
