### PR TITLE
Modify permission in Terraform file/s for simoncreasy-civica

### DIFF
--- a/terraform/hmpps-vcms-app-cp.tf
+++ b/terraform/hmpps-vcms-app-cp.tf
@@ -4,7 +4,7 @@ module "hmpps-vcms-app-cp" {
   collaborators = [
     {
       github_user  = "simoncreasy-civica"
-      permission   = "push"
+      permission   = "maintain"
       name         = "Simon Creasy"
       email        = "simon.creasy@civica.co.uk"
       org          = "Civica"


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator simoncreasy-civica permission on Github is different to the permission in the Terraform file for the repository.

This is because the collaborator is a full organization member, is able to join repositories outside of Terraform and may have different access to the repository now they are in a Team.

The permission on Github is given the priority.

This pull request ensures we keep track of those collaborators, which repositories they are accessing and their permission.

Permission can either be admin, push, maintain, pull or triage.

