### PR TITLE
Modify permission in Terraform file/s for sim-barnes

### DIFF
--- a/terraform/hmpps-domestic-abuse-support-officers.tf
+++ b/terraform/hmpps-domestic-abuse-support-officers.tf
@@ -24,7 +24,7 @@ module "hmpps-domestic-abuse-support-officers" {
     },
     {
       github_user  = "sim-barnes"
-      permission   = "maintain"
+      permission   = "push"
       name         = "Simon Barnes"
       email        = "simon.barnes@civica.co.uk"
       org          = "Civica"

--- a/terraform/hmpps-vcms.tf
+++ b/terraform/hmpps-vcms.tf
@@ -24,7 +24,7 @@ module "hmpps-vcms" {
     },
     {
       github_user  = "sim-barnes"
-      permission   = "maintain"
+      permission   = "push"
       name         = "Simon Barnes"
       email        = "simon.barnes@civica.co.uk"
       org          = "Civica"


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator sim-barnes permission on Github is different to the permission in the Terraform file for the repository.

This is because the collaborator is a full organization member, is able to join repositories outside of Terraform and may have different access to the repository now they are in a Team.

The permission on Github is given the priority.

This pull request ensures we keep track of those collaborators, which repositories they are accessing and their permission.

Permission can either be admin, push, maintain, pull or triage.

