### PR TITLE
Add full Org member / collaborator to Terraform file/s for miriamgo-civica

### DIFF
--- a/terraform/hmpps-vcms-infra-versions.tf
+++ b/terraform/hmpps-vcms-infra-versions.tf
@@ -22,5 +22,15 @@ module "hmpps-vcms-infra-versions" {
       added_by     = "Probation WebOps team, probation-webops@digital.justice.gov.uk"
       review_after = "2022-11-21"
     },
+    {
+      github_user  = "miriamgo-civica"
+      permission   = "push"
+      name         = "Miriam Gomez-Orozco"
+      email        = "Miriam.Gomez-Orozco@civica.co.uk"
+      org          = "civica"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-20"
+    },
   ]
 }

--- a/terraform/hmpps-vcms-terraform.tf
+++ b/terraform/hmpps-vcms-terraform.tf
@@ -1,0 +1,16 @@
+module "hmpps-vcms-terraform" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-vcms-terraform"
+  collaborators = [
+    {
+      github_user  = "miriamgo-civica"
+      permission   = "pull"
+      name         = "Miriam Gomez-Orozco"
+      email        = "Miriam.Gomez-Orozco@civica.co.uk"
+      org          = "civica"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-20"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator miriamgo-civica was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

