### PR TITLE
Modify permission in Terraform file/s for shaunthornburgh

### DIFF
--- a/terraform/hmpps-domestic-abuse-support-officers.tf
+++ b/terraform/hmpps-domestic-abuse-support-officers.tf
@@ -54,7 +54,7 @@ module "hmpps-domestic-abuse-support-officers" {
     },
     {
       github_user  = "shaunthornburgh"
-      permission   = "maintain"
+      permission   = "push"
       name         = "Shaun Thornburgh"
       email        = "shaun.thornburgh@civica.co.uk"
       org          = "Civica"


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator shaunthornburgh permission on Github is different to the permission in the Terraform file for the repository.

This is because the collaborator is a full organization member, is able to join repositories outside of Terraform and may have different access to the repository now they are in a Team.

The permission on Github is given the priority.

This pull request ensures we keep track of those collaborators, which repositories they are accessing and their permission.

Permission can either be admin, push, maintain, pull or triage.

