### PR TITLE
Add full Org member / collaborator to Terraform file/s for bjpirt

### DIFF
--- a/terraform/moj-cjse-exiss.tf
+++ b/terraform/moj-cjse-exiss.tf
@@ -1,0 +1,16 @@
+module "moj-cjse-exiss" {
+  source     = "./modules/repository-collaborators"
+  repository = "moj-cjse-exiss"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "admin"
+      name         = "Ben Pirt"
+      email        = "ben@madetech.com"
+      org          = "Madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-22"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator bjpirt was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

