### PR TITLE
Add full Org member / collaborator to Terraform file/s for simoncreasy-civica

### DIFF
--- a/terraform/hmpps-domestic-abuse-support-officers.tf
+++ b/terraform/hmpps-domestic-abuse-support-officers.tf
@@ -42,5 +42,15 @@ module "hmpps-domestic-abuse-support-officers" {
       added_by     = "Probation Infrastructure AWS Team, awssupportteam@digital.justice.gov.uk"
       review_after = "2023-04-30"
     },
+    {
+      github_user  = "simoncreasy-civica"
+      permission   = "push"
+      name         = "Simon Creasy"
+      email        = "simon.creasy@civica.co.uk"
+      org          = "civica"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-22"
+    },
   ]
 }

--- a/terraform/hmpps-vcms-infra-versions.tf
+++ b/terraform/hmpps-vcms-infra-versions.tf
@@ -22,5 +22,15 @@ module "hmpps-vcms-infra-versions" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "simoncreasy-civica"
+      permission   = "push"
+      name         = "Simon Creasy"
+      email        = "simon.creasy@civica.co.uk"
+      org          = "civica"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-22"
+    },
   ]
 }

--- a/terraform/hmpps-vcms.tf
+++ b/terraform/hmpps-vcms.tf
@@ -32,5 +32,15 @@ module "hmpps-vcms" {
       added_by     = "Probation Infrastructure AWS Team, maximillian.lakanu@digital.justice.gov.uk"
       review_after = "2023-03-31"
     },
+    {
+      github_user  = "simoncreasy-civica"
+      permission   = "push"
+      name         = "Simon Creasy"
+      email        = "simon.creasy@civica.co.uk"
+      org          = "civica"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-02-22"
+    },
   ]
 }


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot. 

The collaborator simoncreasy-civica was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

