### PR TITLE
Modify permission in Terraform file/s for emileswarts

### DIFF
--- a/terraform/aws-root-account.tf
+++ b/terraform/aws-root-account.tf
@@ -14,7 +14,7 @@ module "aws-root-account" {
     },
     {
       github_user  = "emileswarts"
-      permission   = "maintain"
+      permission   = "push"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator emileswarts permission on Github is different to the permission in the Terraform file for the repository.

This is because the collaborator is a full organization member, is able to join repositories outside of Terraform and may have different access to the repository now they are in a Team.

The permission on Github is given the priority.

This pull request ensures we keep track of those collaborators, which repositories they are accessing and their permission.

Permission can either be admin, push, maintain, pull or triage.

