### PR TITLE
Add pen. tester to 'accommodation service' repos

### DIFF
--- a/terraform/hmpps-approved-premises-api.tf
+++ b/terraform/hmpps-approved-premises-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-approved-premises-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-approved-premises-api"
+  collaborators = [
+    {
+      github_user  = "GregJenkinsNCC"
+      permission   = "pull"
+      name         = "Greg Jenkins"
+      email        = "greg.jenkins@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
+    }
+  ]
+}

--- a/terraform/hmpps-approved-premises-ui.tf
+++ b/terraform/hmpps-approved-premises-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-approved-premises-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-approved-premises-ui"
+  collaborators = [
+    {
+      github_user  = "GregJenkinsNCC"
+      permission   = "pull"
+      name         = "Greg Jenkins"
+      email        = "greg.jenkins@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
+    }
+  ]
+}

--- a/terraform/hmpps-temporary-accommodation-ui.tf
+++ b/terraform/hmpps-temporary-accommodation-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-temporary-accommodation-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-temporary-accommodation-ui"
+  collaborators = [
+    {
+      github_user  = "GregJenkinsNCC"
+      permission   = "pull"
+      name         = "Greg Jenkins"
+      email        = "greg.jenkins@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
+    }
+  ]
+}


### PR DESCRIPTION
hmpps-approved-premises-api is the backend of 2 "community accommodation service" frontends:

- Approved Premises (CAS1) hmpps-approved-premises-ui
- Temporary Accommodation (CAS3) hmpps-temporary-accommodation-ui

These 3 apps are being pen. tested together by NCC.