### PR TITLE
Add 3 further pen. testers from NCC to 'accommodation' repos

### DIFF
--- a/terraform/hmpps-approved-premises-api.tf
+++ b/terraform/hmpps-approved-premises-api.tf
@@ -11,6 +11,36 @@ module "hmpps-approved-premises-api" {
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
       review_after = "2023-02-28"
+    },
+    {
+      github_user  = "rr-ncc"
+      permission   = "pull"
+      name         = "Robert Ray"
+      email        = "robert.ray@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
+    },
+    {
+      github_user  = "JonnyOrrNCC"
+      permission   = "pull"
+      name         = "Jonny Orr"
+      email        = "jonny.orr@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
+    },
+    {
+      github_user  = "ThomasWellsNCC"
+      permission   = "pull"
+      name         = "Thomas Wells"
+      email        = "thomas.wells@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
     }
   ]
 }

--- a/terraform/hmpps-approved-premises-ui.tf
+++ b/terraform/hmpps-approved-premises-ui.tf
@@ -11,6 +11,36 @@ module "hmpps-approved-premises-ui" {
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
       review_after = "2023-02-28"
+    },
+    {
+      github_user  = "rr-ncc"
+      permission   = "pull"
+      name         = "Robert Ray"
+      email        = "robert.ray@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
+    },
+    {
+      github_user  = "JonnyOrrNCC"
+      permission   = "pull"
+      name         = "Jonny Orr"
+      email        = "jonny.orr@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
+    },
+    {
+      github_user  = "ThomasWellsNCC"
+      permission   = "pull"
+      name         = "Thomas Wells"
+      email        = "thomas.wells@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
     }
   ]
 }

--- a/terraform/hmpps-temporary-accommodation-ui.tf
+++ b/terraform/hmpps-temporary-accommodation-ui.tf
@@ -11,6 +11,36 @@ module "hmpps-temporary-accommodation-ui" {
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
       review_after = "2023-02-28"
+    },
+    {
+      github_user  = "rr-ncc"
+      permission   = "pull"
+      name         = "Robert Ray"
+      email        = "robert.ray@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
+    },
+    {
+      github_user  = "JonnyOrrNCC"
+      permission   = "pull"
+      name         = "Jonny Orr"
+      email        = "jonny.orr@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
+    },
+    {
+      github_user  = "ThomasWellsNCC"
+      permission   = "pull"
+      name         = "Thomas Wells"
+      email        = "thomas.wells@nccgroup.com"
+      org          = "NCC"
+      reason       = "Pen. tester"
+      added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
+      review_after = "2023-02-28"
     }
   ]
 }


### PR DESCRIPTION
hmpps-approved-premises-api is the backend of 2 "community accommodation service" frontends:

- Approved Premises (CAS1) hmpps-approved-premises-ui
- Temporary Accommodation (CAS3) hmpps-temporary-accommodation-ui

These 3 apps are being pen. tested together by NCC.