### PR TITLE
Add full Org member / collaborator to Terraform file/s for emileswarts

### DIFF
--- a/terraform/aws-root-account.tf
+++ b/terraform/aws-root-account.tf
@@ -22,5 +22,15 @@ module "aws-root-account" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }

--- a/terraform/aws-ta-testing.tf
+++ b/terraform/aws-ta-testing.tf
@@ -12,5 +12,15 @@ module "aws-ta-testing" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }

--- a/terraform/aws-trusted-advisor-to-github-issues.tf
+++ b/terraform/aws-trusted-advisor-to-github-issues.tf
@@ -12,5 +12,15 @@ module "aws-trusted-advisor-to-github-issues" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }

--- a/terraform/cloud-operations-slack-bot.tf
+++ b/terraform/cloud-operations-slack-bot.tf
@@ -12,5 +12,15 @@ module "cloud-operations-slack-bot" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }

--- a/terraform/mojo-aws-github-oidc-provider.tf
+++ b/terraform/mojo-aws-github-oidc-provider.tf
@@ -12,5 +12,15 @@ module "mojo-aws-github-oidc-provider" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }

--- a/terraform/nvvs-devops-github-actions.tf
+++ b/terraform/nvvs-devops-github-actions.tf
@@ -12,5 +12,15 @@ module "nvvs-devops-github-actions" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }

--- a/terraform/nvvs-devops-monitor.tf
+++ b/terraform/nvvs-devops-monitor.tf
@@ -12,5 +12,15 @@ module "nvvs-devops-monitor" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }

--- a/terraform/nvvs-devops.tf
+++ b/terraform/nvvs-devops.tf
@@ -12,5 +12,15 @@ module "nvvs-devops" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }

--- a/terraform/staff-device-logging-dns-dhcp-integration-tests.tf
+++ b/terraform/staff-device-logging-dns-dhcp-integration-tests.tf
@@ -12,5 +12,15 @@ module "staff-device-logging-dns-dhcp-integration-tests" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }

--- a/terraform/staff-device-management-intune-scripts.tf
+++ b/terraform/staff-device-management-intune-scripts.tf
@@ -31,6 +31,16 @@ module "staff-device-management-intune-scripts" {
       reason       = "Full Org member / collaborator missing from Terraform file"
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
-    }
+    },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }

--- a/terraform/staff-infrastructure-admin-sso.tf
+++ b/terraform/staff-infrastructure-admin-sso.tf
@@ -12,5 +12,15 @@ module "staff-infrastructure-admin-sso" {
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
     },
+    {
+      github_user  = "emileswarts"
+      permission   = "pull"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-04-14"
+    },
   ]
 }


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator emileswarts was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

