### PR TITLE
Modify permission in Terraform file/s for emileswarts

### DIFF
--- a/terraform/deployment-tgw.tf
+++ b/terraform/deployment-tgw.tf
@@ -4,7 +4,7 @@ module "deployment-tgw" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/paloalto-pipelines.tf
+++ b/terraform/paloalto-pipelines.tf
@@ -4,7 +4,7 @@ module "paloalto-pipelines" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-device-dhcp-server.tf
+++ b/terraform/staff-device-dhcp-server.tf
@@ -4,7 +4,7 @@ module "staff-device-dhcp-server" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-device-dns-dhcp-admin.tf
+++ b/terraform/staff-device-dns-dhcp-admin.tf
@@ -4,7 +4,7 @@ module "staff-device-dns-dhcp-admin" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-device-dns-dhcp-disaster-recovery.tf
+++ b/terraform/staff-device-dns-dhcp-disaster-recovery.tf
@@ -4,7 +4,7 @@ module "staff-device-dns-dhcp-disaster-recovery" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-device-dns-dhcp-infrastructure.tf
+++ b/terraform/staff-device-dns-dhcp-infrastructure.tf
@@ -4,7 +4,7 @@ module "staff-device-dns-dhcp-infrastructure" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-device-dns-server.tf
+++ b/terraform/staff-device-dns-server.tf
@@ -4,7 +4,7 @@ module "staff-device-dns-server" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-device-logging-infrastructure.tf
+++ b/terraform/staff-device-logging-infrastructure.tf
@@ -4,7 +4,7 @@ module "staff-device-logging-infrastructure" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-device-logging-syslog-to-cloudwatch.tf
+++ b/terraform/staff-device-logging-syslog-to-cloudwatch.tf
@@ -4,7 +4,7 @@ module "staff-device-logging-syslog-to-cloudwatch" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-device-private-dns-zone.tf
+++ b/terraform/staff-device-private-dns-zone.tf
@@ -4,7 +4,7 @@ module "staff-device-private-dns-zone" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-device-shared-services-infrastructure.tf
+++ b/terraform/staff-device-shared-services-infrastructure.tf
@@ -4,7 +4,7 @@ module "staff-device-shared-services-infrastructure" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-infrastructure-certificate-services.tf
+++ b/terraform/staff-infrastructure-certificate-services.tf
@@ -4,7 +4,7 @@ module "staff-infrastructure-certificate-services" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "push"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-infrastructure-metric-aggregator-cloud.tf
+++ b/terraform/staff-infrastructure-metric-aggregator-cloud.tf
@@ -4,7 +4,7 @@ module "staff-infrastructure-metric-aggregator-cloud" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-infrastructure-monitoring-app-reachability.tf
+++ b/terraform/staff-infrastructure-monitoring-app-reachability.tf
@@ -4,7 +4,7 @@ module "staff-infrastructure-monitoring-app-reachability" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-infrastructure-monitoring-blackbox-exporter.tf
+++ b/terraform/staff-infrastructure-monitoring-blackbox-exporter.tf
@@ -4,7 +4,7 @@ module "staff-infrastructure-monitoring-blackbox-exporter" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-infrastructure-monitoring-dns-reachability.tf
+++ b/terraform/staff-infrastructure-monitoring-dns-reachability.tf
@@ -4,7 +4,7 @@ module "staff-infrastructure-monitoring-dns-reachability" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-infrastructure-monitoring-snmpexporter.tf
+++ b/terraform/staff-infrastructure-monitoring-snmpexporter.tf
@@ -4,7 +4,7 @@ module "staff-infrastructure-monitoring-snmpexporter" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "push"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-infrastructure-network-operations.tf
+++ b/terraform/staff-infrastructure-network-operations.tf
@@ -4,7 +4,7 @@ module "staff-infrastructure-network-operations" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-infrastructure-network-services.tf
+++ b/terraform/staff-infrastructure-network-services.tf
@@ -4,7 +4,7 @@ module "staff-infrastructure-network-services" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/staff-infrastructure-smtp-relay-server.tf
+++ b/terraform/staff-infrastructure-smtp-relay-server.tf
@@ -4,7 +4,7 @@ module "staff-infrastructure-smtp-relay-server" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"

--- a/terraform/transit-gateways.tf
+++ b/terraform/transit-gateways.tf
@@ -4,7 +4,7 @@ module "transit-gateways" {
   collaborators = [
     {
       github_user  = "emileswarts"
-      permission   = "admin"
+      permission   = "maintain"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator emileswarts permission on Github is different to the permission in the Terraform file for the repository.

This is because the collaborator is a full organization member, is able to join repositories outside of Terraform and may have different access to the repository now they are in a Team.

The permission on Github is given the priority.

This pull request ensures we keep track of those collaborators, which repositories they are accessing and their permission.

Permission can either be admin, push, maintain, pull or triage.

