### PR TITLE
Modify permission in Terraform file/s for emileswarts

### DIFF
--- a/terraform/staff-device-management-intune-scripts.tf
+++ b/terraform/staff-device-management-intune-scripts.tf
@@ -24,13 +24,13 @@ module "staff-device-management-intune-scripts" {
     },
     {
       github_user  = "emileswarts"
-      permission   = "maintain"
+      permission   = "push"
       name         = "Emile Swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech Ltd"
       reason       = "Full Org member / collaborator missing from Terraform file"
       added_by     = "opseng-bot@digital.justice.gov.uk"
       review_after = "2023-02-20"
-    }
+    },
   ]
 }


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator emileswarts permission on Github is different to the permission in the Terraform file for the repository.

This is because the collaborator is a full organization member, is able to join repositories outside of Terraform and may have different access to the repository now they are in a Team.

The permission on Github is given the priority.

This pull request ensures we keep track of those collaborators, which repositories they are accessing and their permission.

Permission can either be admin, push, maintain, pull or triage.

