### PR TITLE
Add full Org member / collaborator to Terraform file/s for bjpirt

### DIFF
--- a/terraform/basm-move-generator.tf
+++ b/terraform/basm-move-generator.tf
@@ -1,0 +1,16 @@
+module "basm-move-generator" {
+  source     = "./modules/repository-collaborators"
+  repository = "basm-move-generator"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/book-a-prison-visit-staff-ui.tf
+++ b/terraform/book-a-prison-visit-staff-ui.tf
@@ -1,0 +1,16 @@
+module "book-a-prison-visit-staff-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "book-a-prison-visit-staff-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/calculate-release-dates-api.tf
+++ b/terraform/calculate-release-dates-api.tf
@@ -1,0 +1,16 @@
+module "calculate-release-dates-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "calculate-release-dates-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/calculate-release-dates.tf
+++ b/terraform/calculate-release-dates.tf
@@ -1,0 +1,16 @@
+module "calculate-release-dates" {
+  source     = "./modules/repository-collaborators"
+  repository = "calculate-release-dates"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/check-my-diary.tf
+++ b/terraform/check-my-diary.tf
@@ -1,0 +1,16 @@
+module "check-my-diary" {
+  source     = "./modules/repository-collaborators"
+  repository = "check-my-diary"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/cloud-platform-terraform-github-prototype.tf
+++ b/terraform/cloud-platform-terraform-github-prototype.tf
@@ -1,0 +1,16 @@
+module "cloud-platform-terraform-github-prototype" {
+  source     = "./modules/repository-collaborators"
+  repository = "cloud-platform-terraform-github-prototype"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/cmd-api.tf
+++ b/terraform/cmd-api.tf
@@ -1,0 +1,16 @@
+module "cmd-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "cmd-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/community-api.tf
+++ b/terraform/community-api.tf
@@ -1,0 +1,16 @@
+module "community-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "community-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/court-case-matcher.tf
+++ b/terraform/court-case-matcher.tf
@@ -1,0 +1,16 @@
+module "court-case-matcher" {
+  source     = "./modules/repository-collaborators"
+  repository = "court-case-matcher"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/court-case-service.tf
+++ b/terraform/court-case-service.tf
@@ -1,0 +1,16 @@
+module "court-case-service" {
+  source     = "./modules/repository-collaborators"
+  repository = "court-case-service"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/court-case-test-app.tf
+++ b/terraform/court-case-test-app.tf
@@ -1,0 +1,16 @@
+module "court-case-test-app" {
+  source     = "./modules/repository-collaborators"
+  repository = "court-case-test-app"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/court-register.tf
+++ b/terraform/court-register.tf
@@ -1,0 +1,16 @@
+module "court-register" {
+  source     = "./modules/repository-collaborators"
+  repository = "court-register"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/create-and-vary-a-licence-api.tf
+++ b/terraform/create-and-vary-a-licence-api.tf
@@ -1,0 +1,16 @@
+module "create-and-vary-a-licence-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "create-and-vary-a-licence-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/create-and-vary-a-licence.tf
+++ b/terraform/create-and-vary-a-licence.tf
@@ -1,0 +1,16 @@
+module "create-and-vary-a-licence" {
+  source     = "./modules/repository-collaborators"
+  repository = "create-and-vary-a-licence"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/csr-api.tf
+++ b/terraform/csr-api.tf
@@ -1,0 +1,16 @@
+module "csr-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "csr-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/deployment-tools.tf
+++ b/terraform/deployment-tools.tf
@@ -1,0 +1,16 @@
+module "deployment-tools" {
+  source     = "./modules/repository-collaborators"
+  repository = "deployment-tools"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "maintain"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/digital-prison-services.tf
+++ b/terraform/digital-prison-services.tf
@@ -1,0 +1,16 @@
+module "digital-prison-services" {
+  source     = "./modules/repository-collaborators"
+  repository = "digital-prison-services"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/dps-data-compliance.tf
+++ b/terraform/dps-data-compliance.tf
@@ -1,0 +1,16 @@
+module "dps-data-compliance" {
+  source     = "./modules/repository-collaborators"
+  repository = "dps-data-compliance"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/dps-gradle-spring-boot.tf
+++ b/terraform/dps-gradle-spring-boot.tf
@@ -1,0 +1,16 @@
+module "dps-gradle-spring-boot" {
+  source     = "./modules/repository-collaborators"
+  repository = "dps-gradle-spring-boot"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/dps-monitor.tf
+++ b/terraform/dps-monitor.tf
@@ -1,0 +1,16 @@
+module "dps-monitor" {
+  source     = "./modules/repository-collaborators"
+  repository = "dps-monitor"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/dps-project-bootstrap.tf
+++ b/terraform/dps-project-bootstrap.tf
@@ -1,0 +1,16 @@
+module "dps-project-bootstrap" {
+  source     = "./modules/repository-collaborators"
+  repository = "dps-project-bootstrap"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/education-data-aggregation.tf
+++ b/terraform/education-data-aggregation.tf
@@ -1,0 +1,16 @@
+module "education-data-aggregation" {
+  source     = "./modules/repository-collaborators"
+  repository = "education-data-aggregation"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/education-skills-work-employment.tf
+++ b/terraform/education-skills-work-employment.tf
@@ -1,0 +1,16 @@
+module "education-skills-work-employment" {
+  source     = "./modules/repository-collaborators"
+  repository = "education-skills-work-employment"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/elp-scripts.tf
+++ b/terraform/elp-scripts.tf
@@ -1,0 +1,16 @@
+module "elp-scripts" {
+  source     = "./modules/repository-collaborators"
+  repository = "elp-scripts"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/help-with-prison-visits-asynchronous-worker.tf
+++ b/terraform/help-with-prison-visits-asynchronous-worker.tf
@@ -1,0 +1,16 @@
+module "help-with-prison-visits-asynchronous-worker" {
+  source     = "./modules/repository-collaborators"
+  repository = "help-with-prison-visits-asynchronous-worker"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/help-with-prison-visits-database.tf
+++ b/terraform/help-with-prison-visits-database.tf
@@ -1,0 +1,16 @@
+module "help-with-prison-visits-database" {
+  source     = "./modules/repository-collaborators"
+  repository = "help-with-prison-visits-database"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/help-with-prison-visits-external.tf
+++ b/terraform/help-with-prison-visits-external.tf
@@ -1,0 +1,16 @@
+module "help-with-prison-visits-external" {
+  source     = "./modules/repository-collaborators"
+  repository = "help-with-prison-visits-external"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/help-with-prison-visits-internal.tf
+++ b/terraform/help-with-prison-visits-internal.tf
@@ -1,0 +1,16 @@
+module "help-with-prison-visits-internal" {
+  source     = "./modules/repository-collaborators"
+  repository = "help-with-prison-visits-internal"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/help-with-prison-visits-maintenance.tf
+++ b/terraform/help-with-prison-visits-maintenance.tf
@@ -1,0 +1,16 @@
+module "help-with-prison-visits-maintenance" {
+  source     = "./modules/repository-collaborators"
+  repository = "help-with-prison-visits-maintenance"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-activities-management-api.tf
+++ b/terraform/hmpps-activities-management-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-activities-management-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-activities-management-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-activities-management.tf
+++ b/terraform/hmpps-activities-management.tf
@@ -1,0 +1,16 @@
+module "hmpps-activities-management" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-activities-management"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-allocations.tf
+++ b/terraform/hmpps-allocations.tf
@@ -1,0 +1,16 @@
+module "hmpps-allocations" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-allocations"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-approved-premises-api.tf
+++ b/terraform/hmpps-approved-premises-api.tf
@@ -3,7 +3,7 @@ module "hmpps-approved-premises-api" {
   repository = "hmpps-approved-premises-api"
   collaborators = [
     {
-      github_user  = "GregJenkinsNCC"
+      github_user  = "gregjenkinsncc"
       permission   = "pull"
       name         = "Greg Jenkins"
       email        = "greg.jenkins@nccgroup.com"
@@ -23,7 +23,7 @@ module "hmpps-approved-premises-api" {
       review_after = "2023-02-28"
     },
     {
-      github_user  = "JonnyOrrNCC"
+      github_user  = "jonnyorrncc"
       permission   = "pull"
       name         = "Jonny Orr"
       email        = "jonny.orr@nccgroup.com"
@@ -33,7 +33,7 @@ module "hmpps-approved-premises-api" {
       review_after = "2023-02-28"
     },
     {
-      github_user  = "ThomasWellsNCC"
+      github_user  = "thomaswellsncc"
       permission   = "pull"
       name         = "Thomas Wells"
       email        = "thomas.wells@nccgroup.com"
@@ -41,6 +41,16 @@ module "hmpps-approved-premises-api" {
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
       review_after = "2023-02-28"
-    }
+    },
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
   ]
 }

--- a/terraform/hmpps-approved-premises-ui.tf
+++ b/terraform/hmpps-approved-premises-ui.tf
@@ -3,7 +3,7 @@ module "hmpps-approved-premises-ui" {
   repository = "hmpps-approved-premises-ui"
   collaborators = [
     {
-      github_user  = "GregJenkinsNCC"
+      github_user  = "gregjenkinsncc"
       permission   = "pull"
       name         = "Greg Jenkins"
       email        = "greg.jenkins@nccgroup.com"
@@ -23,7 +23,7 @@ module "hmpps-approved-premises-ui" {
       review_after = "2023-02-28"
     },
     {
-      github_user  = "JonnyOrrNCC"
+      github_user  = "jonnyorrncc"
       permission   = "pull"
       name         = "Jonny Orr"
       email        = "jonny.orr@nccgroup.com"
@@ -33,7 +33,7 @@ module "hmpps-approved-premises-ui" {
       review_after = "2023-02-28"
     },
     {
-      github_user  = "ThomasWellsNCC"
+      github_user  = "thomaswellsncc"
       permission   = "pull"
       name         = "Thomas Wells"
       email        = "thomas.wells@nccgroup.com"
@@ -41,6 +41,16 @@ module "hmpps-approved-premises-ui" {
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
       review_after = "2023-02-28"
-    }
+    },
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
   ]
 }

--- a/terraform/hmpps-architecture-as-code.tf
+++ b/terraform/hmpps-architecture-as-code.tf
@@ -1,0 +1,16 @@
+module "hmpps-architecture-as-code" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-architecture-as-code"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-assess-risks-and-needs.tf
+++ b/terraform/hmpps-assess-risks-and-needs.tf
@@ -1,0 +1,16 @@
+module "hmpps-assess-risks-and-needs" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-assess-risks-and-needs"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-audit-poc-api.tf
+++ b/terraform/hmpps-audit-poc-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-audit-poc-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-audit-poc-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-audit-poc-ui.tf
+++ b/terraform/hmpps-audit-poc-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-audit-poc-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-audit-poc-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-auth-performance-tests.tf
+++ b/terraform/hmpps-auth-performance-tests.tf
@@ -1,0 +1,16 @@
+module "hmpps-auth-performance-tests" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-auth-performance-tests"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-auth.tf
+++ b/terraform/hmpps-auth.tf
@@ -1,0 +1,16 @@
+module "hmpps-auth" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-auth"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-authorization-server.tf
+++ b/terraform/hmpps-authorization-server.tf
@@ -1,0 +1,16 @@
+module "hmpps-authorization-server" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-authorization-server"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-book-a-prison-visit-internal-admin-ui.tf
+++ b/terraform/hmpps-book-a-prison-visit-internal-admin-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-book-a-prison-visit-internal-admin-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-book-a-prison-visit-internal-admin-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-book-a-prison-visit-ui.tf
+++ b/terraform/hmpps-book-a-prison-visit-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-book-a-prison-visit-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-book-a-prison-visit-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-book-video-link.tf
+++ b/terraform/hmpps-book-video-link.tf
@@ -1,0 +1,16 @@
+module "hmpps-book-video-link" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-book-video-link"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-circleci-orb.tf
+++ b/terraform/hmpps-circleci-orb.tf
@@ -1,0 +1,16 @@
+module "hmpps-circleci-orb" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-circleci-orb"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-community-accommodation-wiremock.tf
+++ b/terraform/hmpps-community-accommodation-wiremock.tf
@@ -1,0 +1,16 @@
+module "hmpps-community-accommodation-wiremock" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-community-accommodation-wiremock"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-community-api-wiremock.tf
+++ b/terraform/hmpps-community-api-wiremock.tf
@@ -1,0 +1,16 @@
+module "hmpps-community-api-wiremock" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-community-api-wiremock"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-delius-api.tf
+++ b/terraform/hmpps-delius-api.tf
@@ -32,5 +32,15 @@ module "hmpps-delius-api" {
       added_by     = "Nicola Hodgkinson <nicola.hodgkinson@justice.gov.uk>"
       review_after = "2023-02-25"
     },
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
   ]
 }

--- a/terraform/hmpps-digital-developer-recruitment.tf
+++ b/terraform/hmpps-digital-developer-recruitment.tf
@@ -1,0 +1,16 @@
+module "hmpps-digital-developer-recruitment" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-digital-developer-recruitment"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "pull"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-domain-event-logger.tf
+++ b/terraform/hmpps-domain-event-logger.tf
@@ -1,0 +1,16 @@
+module "hmpps-domain-event-logger" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-domain-event-logger"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-domain-events.tf
+++ b/terraform/hmpps-domain-events.tf
@@ -1,0 +1,16 @@
+module "hmpps-domain-events" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-domain-events"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-education-employment-api.tf
+++ b/terraform/hmpps-education-employment-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-education-employment-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-education-employment-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-education-employment-ui.tf
+++ b/terraform/hmpps-education-employment-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-education-employment-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-education-employment-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-engineering-accelerator-team.tf
+++ b/terraform/hmpps-engineering-accelerator-team.tf
@@ -1,0 +1,16 @@
+module "hmpps-engineering-accelerator-team" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-engineering-accelerator-team"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "pull"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-external-users-api.tf
+++ b/terraform/hmpps-external-users-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-external-users-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-external-users-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-helm-charts.tf
+++ b/terraform/hmpps-helm-charts.tf
@@ -1,0 +1,16 @@
+module "hmpps-helm-charts" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-helm-charts"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-historical-prisoner-api.tf
+++ b/terraform/hmpps-historical-prisoner-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-historical-prisoner-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-historical-prisoner-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-historical-prisoner-indexer.tf
+++ b/terraform/hmpps-historical-prisoner-indexer.tf
@@ -1,0 +1,16 @@
+module "hmpps-historical-prisoner-indexer" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-historical-prisoner-indexer"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-historical-prisoner.tf
+++ b/terraform/hmpps-historical-prisoner.tf
@@ -1,0 +1,16 @@
+module "hmpps-historical-prisoner" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-historical-prisoner"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-incentives-api.tf
+++ b/terraform/hmpps-incentives-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-incentives-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-incentives-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-incentives-ui.tf
+++ b/terraform/hmpps-incentives-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-incentives-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-incentives-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-interventions-docs.tf
+++ b/terraform/hmpps-interventions-docs.tf
@@ -1,0 +1,16 @@
+module "hmpps-interventions-docs" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-interventions-docs"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-interventions-seed-data.tf
+++ b/terraform/hmpps-interventions-seed-data.tf
@@ -1,0 +1,16 @@
+module "hmpps-interventions-seed-data" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-interventions-seed-data"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-interventions-service.tf
+++ b/terraform/hmpps-interventions-service.tf
@@ -1,0 +1,16 @@
+module "hmpps-interventions-service" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-interventions-service"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-interventions-ui.tf
+++ b/terraform/hmpps-interventions-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-interventions-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-interventions-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-it-incident-hub.tf
+++ b/terraform/hmpps-it-incident-hub.tf
@@ -1,0 +1,16 @@
+module "hmpps-it-incident-hub" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-it-incident-hub"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-manage-a-warrant-folder-api.tf
+++ b/terraform/hmpps-manage-a-warrant-folder-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-manage-a-warrant-folder-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-manage-a-warrant-folder-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-manage-a-warrant-folder.tf
+++ b/terraform/hmpps-manage-a-warrant-folder.tf
@@ -1,0 +1,16 @@
+module "hmpps-manage-a-warrant-folder" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-manage-a-warrant-folder"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-manage-adjudications-api.tf
+++ b/terraform/hmpps-manage-adjudications-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-manage-adjudications-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-manage-adjudications-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-manage-adjudications.tf
+++ b/terraform/hmpps-manage-adjudications.tf
@@ -1,0 +1,16 @@
+module "hmpps-manage-adjudications" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-manage-adjudications"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-manage-offences-api.tf
+++ b/terraform/hmpps-manage-offences-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-manage-offences-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-manage-offences-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-manage-offences.tf
+++ b/terraform/hmpps-manage-offences.tf
@@ -1,0 +1,16 @@
+module "hmpps-manage-offences" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-manage-offences"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-manage-prison-visits-orchestration.tf
+++ b/terraform/hmpps-manage-prison-visits-orchestration.tf
@@ -1,0 +1,16 @@
+module "hmpps-manage-prison-visits-orchestration" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-manage-prison-visits-orchestration"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-manage-users-api.tf
+++ b/terraform/hmpps-manage-users-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-manage-users-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-manage-users-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-manage-users.tf
+++ b/terraform/hmpps-manage-users.tf
@@ -1,0 +1,16 @@
+module "hmpps-manage-users" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-manage-users"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-micro-frontend-poc-component.tf
+++ b/terraform/hmpps-micro-frontend-poc-component.tf
@@ -1,0 +1,16 @@
+module "hmpps-micro-frontend-poc-component" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-micro-frontend-poc-component"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-micro-frontend-poc.tf
+++ b/terraform/hmpps-micro-frontend-poc.tf
@@ -1,0 +1,16 @@
+module "hmpps-micro-frontend-poc" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-micro-frontend-poc"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-nomis-mapping-service.tf
+++ b/terraform/hmpps-nomis-mapping-service.tf
@@ -1,0 +1,16 @@
+module "hmpps-nomis-mapping-service" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-nomis-mapping-service"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-nomis-prisoner-api.tf
+++ b/terraform/hmpps-nomis-prisoner-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-nomis-prisoner-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-nomis-prisoner-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-nomis-sync-dashboard.tf
+++ b/terraform/hmpps-nomis-sync-dashboard.tf
@@ -1,0 +1,16 @@
+module "hmpps-nomis-sync-dashboard" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-nomis-sync-dashboard"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-pact-broker.tf
+++ b/terraform/hmpps-pact-broker.tf
@@ -1,0 +1,16 @@
+module "hmpps-pact-broker" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-pact-broker"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-person-match-score.tf
+++ b/terraform/hmpps-person-match-score.tf
@@ -1,0 +1,16 @@
+module "hmpps-person-match-score" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-person-match-score"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-prisoner-contacts.tf
+++ b/terraform/hmpps-prisoner-contacts.tf
@@ -1,0 +1,16 @@
+module "hmpps-prisoner-contacts" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-prisoner-contacts"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-prisoner-events.tf
+++ b/terraform/hmpps-prisoner-events.tf
@@ -1,0 +1,16 @@
+module "hmpps-prisoner-events" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-prisoner-events"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-prisoner-from-nomis-migration.tf
+++ b/terraform/hmpps-prisoner-from-nomis-migration.tf
@@ -1,0 +1,16 @@
+module "hmpps-prisoner-from-nomis-migration" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-prisoner-from-nomis-migration"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-prisoner-profile.tf
+++ b/terraform/hmpps-prisoner-profile.tf
@@ -1,0 +1,16 @@
+module "hmpps-prisoner-profile" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-prisoner-profile"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-prisoner-to-nomis-update.tf
+++ b/terraform/hmpps-prisoner-to-nomis-update.tf
@@ -1,0 +1,16 @@
+module "hmpps-prisoner-to-nomis-update" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-prisoner-to-nomis-update"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-probation-estate-api.tf
+++ b/terraform/hmpps-probation-estate-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-probation-estate-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-probation-estate-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-probation-integration-scripts.tf
+++ b/terraform/hmpps-probation-integration-scripts.tf
@@ -1,0 +1,16 @@
+module "hmpps-probation-integration-scripts" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-probation-integration-scripts"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-probation-integration-services.tf
+++ b/terraform/hmpps-probation-integration-services.tf
@@ -1,0 +1,16 @@
+module "hmpps-probation-integration-services" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-probation-integration-services"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-reference-data.tf
+++ b/terraform/hmpps-reference-data.tf
@@ -1,0 +1,16 @@
+module "hmpps-reference-data" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-reference-data"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-restricted-patients.tf
+++ b/terraform/hmpps-restricted-patients.tf
@@ -1,0 +1,16 @@
+module "hmpps-restricted-patients" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-restricted-patients"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-spring-boot-sqs.tf
+++ b/terraform/hmpps-spring-boot-sqs.tf
@@ -1,0 +1,16 @@
+module "hmpps-spring-boot-sqs" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-spring-boot-sqs"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-staff-lookup-service.tf
+++ b/terraform/hmpps-staff-lookup-service.tf
@@ -1,0 +1,16 @@
+module "hmpps-staff-lookup-service" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-staff-lookup-service"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-tech-docs.tf
+++ b/terraform/hmpps-tech-docs.tf
@@ -1,0 +1,16 @@
+module "hmpps-tech-docs" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-tech-docs"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-template-kotlin.tf
+++ b/terraform/hmpps-template-kotlin.tf
@@ -1,0 +1,16 @@
+module "hmpps-template-kotlin" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-template-kotlin"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-template-typescript.tf
+++ b/terraform/hmpps-template-typescript.tf
@@ -1,0 +1,16 @@
+module "hmpps-template-typescript" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-template-typescript"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-temporary-accommodation-ui.tf
+++ b/terraform/hmpps-temporary-accommodation-ui.tf
@@ -3,7 +3,7 @@ module "hmpps-temporary-accommodation-ui" {
   repository = "hmpps-temporary-accommodation-ui"
   collaborators = [
     {
-      github_user  = "GregJenkinsNCC"
+      github_user  = "gregjenkinsncc"
       permission   = "pull"
       name         = "Greg Jenkins"
       email        = "greg.jenkins@nccgroup.com"
@@ -23,7 +23,7 @@ module "hmpps-temporary-accommodation-ui" {
       review_after = "2023-02-28"
     },
     {
-      github_user  = "JonnyOrrNCC"
+      github_user  = "jonnyorrncc"
       permission   = "pull"
       name         = "Jonny Orr"
       email        = "jonny.orr@nccgroup.com"
@@ -33,7 +33,7 @@ module "hmpps-temporary-accommodation-ui" {
       review_after = "2023-02-28"
     },
     {
-      github_user  = "ThomasWellsNCC"
+      github_user  = "thomaswellsncc"
       permission   = "pull"
       name         = "Thomas Wells"
       email        = "thomas.wells@nccgroup.com"
@@ -41,6 +41,16 @@ module "hmpps-temporary-accommodation-ui" {
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
       review_after = "2023-02-28"
-    }
+    },
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
   ]
 }

--- a/terraform/hmpps-tier.tf
+++ b/terraform/hmpps-tier.tf
@@ -1,0 +1,16 @@
+module "hmpps-tier" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-tier"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-utility-container-images.tf
+++ b/terraform/hmpps-utility-container-images.tf
@@ -1,0 +1,16 @@
+module "hmpps-utility-container-images" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-utility-container-images"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-vsip-internal-admin-ui.tf
+++ b/terraform/hmpps-vsip-internal-admin-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-vsip-internal-admin-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-vsip-internal-admin-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-welcome-people-into-prison-api.tf
+++ b/terraform/hmpps-welcome-people-into-prison-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-welcome-people-into-prison-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-welcome-people-into-prison-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-welcome-people-into-prison-ui.tf
+++ b/terraform/hmpps-welcome-people-into-prison-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-welcome-people-into-prison-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-welcome-people-into-prison-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-wmt-migration.tf
+++ b/terraform/hmpps-wmt-migration.tf
@@ -1,0 +1,16 @@
+module "hmpps-wmt-migration" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-wmt-migration"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/hmpps-workload.tf
+++ b/terraform/hmpps-workload.tf
@@ -1,0 +1,16 @@
+module "hmpps-workload" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-workload"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/keyworker-api.tf
+++ b/terraform/keyworker-api.tf
@@ -1,0 +1,16 @@
+module "keyworker-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "keyworker-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/legacy-ppud-api.tf
+++ b/terraform/legacy-ppud-api.tf
@@ -1,0 +1,16 @@
+module "legacy-ppud-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "legacy-ppud-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/licences.tf
+++ b/terraform/licences.tf
@@ -1,0 +1,16 @@
+module "licences" {
+  source     = "./modules/repository-collaborators"
+  repository = "licences"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/manage-a-workforce-ui.tf
+++ b/terraform/manage-a-workforce-ui.tf
@@ -1,0 +1,16 @@
+module "manage-a-workforce-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-a-workforce-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/manage-key-workers.tf
+++ b/terraform/manage-key-workers.tf
@@ -1,0 +1,16 @@
+module "manage-key-workers" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-key-workers"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/manage-recalls-api.tf
+++ b/terraform/manage-recalls-api.tf
@@ -1,0 +1,16 @@
+module "manage-recalls-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-recalls-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/manage-recalls-error-pages.tf
+++ b/terraform/manage-recalls-error-pages.tf
@@ -1,0 +1,16 @@
+module "manage-recalls-error-pages" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-recalls-error-pages"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/manage-recalls-ui.tf
+++ b/terraform/manage-recalls-ui.tf
@@ -1,0 +1,16 @@
+module "manage-recalls-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-recalls-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/manage-soc-cases-api.tf
+++ b/terraform/manage-soc-cases-api.tf
@@ -1,0 +1,16 @@
+module "manage-soc-cases-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-soc-cases-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/manage-soc-cases.tf
+++ b/terraform/manage-soc-cases.tf
@@ -1,0 +1,16 @@
+module "manage-soc-cases" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-soc-cases"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/nomis-api-terraform-azure.tf
+++ b/terraform/nomis-api-terraform-azure.tf
@@ -1,0 +1,16 @@
+module "nomis-api-terraform-azure" {
+  source     = "./modules/repository-collaborators"
+  repository = "nomis-api-terraform-azure"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/nomis-prisoner-deletion-service.tf
+++ b/terraform/nomis-prisoner-deletion-service.tf
@@ -1,0 +1,16 @@
+module "nomis-prisoner-deletion-service" {
+  source     = "./modules/repository-collaborators"
+  repository = "nomis-prisoner-deletion-service"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/nomis-user-roles-api.tf
+++ b/terraform/nomis-user-roles-api.tf
@@ -1,0 +1,16 @@
+module "nomis-user-roles-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "nomis-user-roles-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/offender-case-notes.tf
+++ b/terraform/offender-case-notes.tf
@@ -1,0 +1,16 @@
+module "offender-case-notes" {
+  source     = "./modules/repository-collaborators"
+  repository = "offender-case-notes"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/offender-events-ui.tf
+++ b/terraform/offender-events-ui.tf
@@ -1,0 +1,16 @@
+module "offender-events-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "offender-events-ui"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "maintain"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/offloc-server.tf
+++ b/terraform/offloc-server.tf
@@ -1,0 +1,16 @@
+module "offloc-server" {
+  source     = "./modules/repository-collaborators"
+  repository = "offloc-server"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/ppud-replacement-bandiera.tf
+++ b/terraform/ppud-replacement-bandiera.tf
@@ -1,0 +1,16 @@
+module "ppud-replacement-bandiera" {
+  source     = "./modules/repository-collaborators"
+  repository = "ppud-replacement-bandiera"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/ppud-replacement-dashboards.tf
+++ b/terraform/ppud-replacement-dashboards.tf
@@ -1,0 +1,16 @@
+module "ppud-replacement-dashboards" {
+  source     = "./modules/repository-collaborators"
+  repository = "ppud-replacement-dashboards"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/pre-sentence-service-wproofreader.tf
+++ b/terraform/pre-sentence-service-wproofreader.tf
@@ -1,0 +1,16 @@
+module "pre-sentence-service-wproofreader" {
+  source     = "./modules/repository-collaborators"
+  repository = "pre-sentence-service-wproofreader"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/pre-sentence-service.tf
+++ b/terraform/pre-sentence-service.tf
@@ -1,0 +1,16 @@
+module "pre-sentence-service" {
+  source     = "./modules/repository-collaborators"
+  repository = "pre-sentence-service"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prepare-a-case.tf
+++ b/terraform/prepare-a-case.tf
@@ -1,0 +1,16 @@
+module "prepare-a-case" {
+  source     = "./modules/repository-collaborators"
+  repository = "prepare-a-case"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prison-api.tf
+++ b/terraform/prison-api.tf
@@ -1,0 +1,16 @@
+module "prison-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prison-offender-events.tf
+++ b/terraform/prison-offender-events.tf
@@ -1,0 +1,16 @@
+module "prison-offender-events" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-offender-events"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prison-services-feedback-and-support.tf
+++ b/terraform/prison-services-feedback-and-support.tf
@@ -1,0 +1,16 @@
+module "prison-services-feedback-and-support" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-services-feedback-and-support"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prison-to-probation-update.tf
+++ b/terraform/prison-to-probation-update.tf
@@ -1,0 +1,16 @@
+module "prison-to-probation-update" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-to-probation-update"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prison-visits-2.tf
+++ b/terraform/prison-visits-2.tf
@@ -1,0 +1,16 @@
+module "prison-visits-2" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-visits-2"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prisoner-contact-registry.tf
+++ b/terraform/prisoner-contact-registry.tf
@@ -1,0 +1,16 @@
+module "prisoner-contact-registry" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-contact-registry"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prisoner-content-hub-backend.tf
+++ b/terraform/prisoner-content-hub-backend.tf
@@ -1,0 +1,16 @@
+module "prisoner-content-hub-backend" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-content-hub-backend"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prisoner-content-hub-feedback-exporter.tf
+++ b/terraform/prisoner-content-hub-feedback-exporter.tf
@@ -1,0 +1,16 @@
+module "prisoner-content-hub-feedback-exporter" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-content-hub-feedback-exporter"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prisoner-content-hub-frontend.tf
+++ b/terraform/prisoner-content-hub-frontend.tf
@@ -1,0 +1,16 @@
+module "prisoner-content-hub-frontend" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-content-hub-frontend"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prisoner-content-hub.tf
+++ b/terraform/prisoner-content-hub.tf
@@ -1,0 +1,16 @@
+module "prisoner-content-hub" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-content-hub"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/prisoner-offender-search.tf
+++ b/terraform/prisoner-offender-search.tf
@@ -1,0 +1,16 @@
+module "prisoner-offender-search" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-offender-search"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/probation-offender-search.tf
+++ b/terraform/probation-offender-search.tf
@@ -1,0 +1,16 @@
+module "probation-offender-search" {
+  source     = "./modules/repository-collaborators"
+  repository = "probation-offender-search"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/probation-teams.tf
+++ b/terraform/probation-teams.tf
@@ -1,0 +1,16 @@
+module "probation-teams" {
+  source     = "./modules/repository-collaborators"
+  repository = "probation-teams"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/send-legal-mail-to-prisons-api.tf
+++ b/terraform/send-legal-mail-to-prisons-api.tf
@@ -1,0 +1,16 @@
+module "send-legal-mail-to-prisons-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "send-legal-mail-to-prisons-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/send-legal-mail-to-prisons.tf
+++ b/terraform/send-legal-mail-to-prisons.tf
@@ -1,0 +1,16 @@
+module "send-legal-mail-to-prisons" {
+  source     = "./modules/repository-collaborators"
+  repository = "send-legal-mail-to-prisons"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/token-verification-api.tf
+++ b/terraform/token-verification-api.tf
@@ -1,0 +1,16 @@
+module "token-verification-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "token-verification-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/use-of-force.tf
+++ b/terraform/use-of-force.tf
@@ -1,0 +1,16 @@
+module "use-of-force" {
+  source     = "./modules/repository-collaborators"
+  repository = "use-of-force"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/visit-scheduler.tf
+++ b/terraform/visit-scheduler.tf
@@ -1,0 +1,16 @@
+module "visit-scheduler" {
+  source     = "./modules/repository-collaborators"
+  repository = "visit-scheduler"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/whereabouts-api.tf
+++ b/terraform/whereabouts-api.tf
@@ -1,0 +1,16 @@
+module "whereabouts-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "whereabouts-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/wmt-web.tf
+++ b/terraform/wmt-web.tf
@@ -1,0 +1,16 @@
+module "wmt-web" {
+  source     = "./modules/repository-collaborators"
+  repository = "wmt-web"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}

--- a/terraform/wmt-worker.tf
+++ b/terraform/wmt-worker.tf
@@ -1,0 +1,16 @@
+module "wmt-worker" {
+  source     = "./modules/repository-collaborators"
+  repository = "wmt-worker"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-22"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator bjpirt was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

