### PR TITLE
Extend review date in Terraform file/s for rr-ncc

### DIFF
--- a/terraform/hmpps-approved-premises-api.tf
+++ b/terraform/hmpps-approved-premises-api.tf
@@ -3,7 +3,7 @@ module "hmpps-approved-premises-api" {
   repository = "hmpps-approved-premises-api"
   collaborators = [
     {
-      github_user  = "GregJenkinsNCC"
+      github_user  = "gregjenkinsncc"
       permission   = "pull"
       name         = "Greg Jenkins"
       email        = "greg.jenkins@nccgroup.com"
@@ -20,10 +20,10 @@ module "hmpps-approved-premises-api" {
       org          = "NCC"
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
-      review_after = "2023-02-28"
+      review_after = "2023-08-27"
     },
     {
-      github_user  = "JonnyOrrNCC"
+      github_user  = "jonnyorrncc"
       permission   = "pull"
       name         = "Jonny Orr"
       email        = "jonny.orr@nccgroup.com"
@@ -33,7 +33,7 @@ module "hmpps-approved-premises-api" {
       review_after = "2023-02-28"
     },
     {
-      github_user  = "ThomasWellsNCC"
+      github_user  = "thomaswellsncc"
       permission   = "pull"
       name         = "Thomas Wells"
       email        = "thomas.wells@nccgroup.com"
@@ -41,6 +41,6 @@ module "hmpps-approved-premises-api" {
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
       review_after = "2023-02-28"
-    }
+    },
   ]
 }

--- a/terraform/hmpps-approved-premises-ui.tf
+++ b/terraform/hmpps-approved-premises-ui.tf
@@ -3,7 +3,7 @@ module "hmpps-approved-premises-ui" {
   repository = "hmpps-approved-premises-ui"
   collaborators = [
     {
-      github_user  = "GregJenkinsNCC"
+      github_user  = "gregjenkinsncc"
       permission   = "pull"
       name         = "Greg Jenkins"
       email        = "greg.jenkins@nccgroup.com"
@@ -20,10 +20,10 @@ module "hmpps-approved-premises-ui" {
       org          = "NCC"
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
-      review_after = "2023-02-28"
+      review_after = "2023-08-27"
     },
     {
-      github_user  = "JonnyOrrNCC"
+      github_user  = "jonnyorrncc"
       permission   = "pull"
       name         = "Jonny Orr"
       email        = "jonny.orr@nccgroup.com"
@@ -33,7 +33,7 @@ module "hmpps-approved-premises-ui" {
       review_after = "2023-02-28"
     },
     {
-      github_user  = "ThomasWellsNCC"
+      github_user  = "thomaswellsncc"
       permission   = "pull"
       name         = "Thomas Wells"
       email        = "thomas.wells@nccgroup.com"
@@ -41,6 +41,6 @@ module "hmpps-approved-premises-ui" {
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
       review_after = "2023-02-28"
-    }
+    },
   ]
 }

--- a/terraform/hmpps-temporary-accommodation-ui.tf
+++ b/terraform/hmpps-temporary-accommodation-ui.tf
@@ -3,7 +3,7 @@ module "hmpps-temporary-accommodation-ui" {
   repository = "hmpps-temporary-accommodation-ui"
   collaborators = [
     {
-      github_user  = "GregJenkinsNCC"
+      github_user  = "gregjenkinsncc"
       permission   = "pull"
       name         = "Greg Jenkins"
       email        = "greg.jenkins@nccgroup.com"
@@ -20,10 +20,10 @@ module "hmpps-temporary-accommodation-ui" {
       org          = "NCC"
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
-      review_after = "2023-02-28"
+      review_after = "2023-08-27"
     },
     {
-      github_user  = "JonnyOrrNCC"
+      github_user  = "jonnyorrncc"
       permission   = "pull"
       name         = "Jonny Orr"
       email        = "jonny.orr@nccgroup.com"
@@ -33,7 +33,7 @@ module "hmpps-temporary-accommodation-ui" {
       review_after = "2023-02-28"
     },
     {
-      github_user  = "ThomasWellsNCC"
+      github_user  = "thomaswellsncc"
       permission   = "pull"
       name         = "Thomas Wells"
       email        = "thomas.wells@nccgroup.com"
@@ -41,6 +41,6 @@ module "hmpps-temporary-accommodation-ui" {
       reason       = "Pen. tester"
       added_by     = "Ed Davey <ed.davey@digital.justice.gov.uk>"
       review_after = "2023-02-28"
-    }
+    },
   ]
 }


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator rr-ncc has review date/s that are close to expiring.

The review date/s have automatically been extended.

Either approve this pull request, modify it or delete it if it is no longer necessary.
