### PR TITLE
Add full Org member / collaborator to Terraform file/s for miriamgo-civica

### DIFF
--- a/terraform/sentinel.tf
+++ b/terraform/sentinel.tf
@@ -1,0 +1,16 @@
+module "sentinel" {
+  source     = "./modules/repository-collaborators"
+  repository = "sentinel"
+  collaborators = [
+    {
+      github_user  = "miriamgo-civica"
+      permission   = "push"
+      name         = "miriam gomez-orozco"
+      email        = "miriam.gomez-orozco@civica.co.uk"
+      org          = "civica"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-25"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator miriamgo-civica was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

