### PR TITLE
Add full Org member / collaborator to Terraform file/s for emileswarts

### DIFF
--- a/terraform/hmpps-utility-container-images.tf
+++ b/terraform/hmpps-utility-container-images.tf
@@ -1,0 +1,16 @@
+module "hmpps-utility-container-images" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-utility-container-images"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/hmpps-visits-internal-admin-ui.tf
+++ b/terraform/hmpps-visits-internal-admin-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-visits-internal-admin-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-visits-internal-admin-ui"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/hmpps-welcome-people-into-prison-api.tf
+++ b/terraform/hmpps-welcome-people-into-prison-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-welcome-people-into-prison-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-welcome-people-into-prison-api"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/hmpps-welcome-people-into-prison-ui.tf
+++ b/terraform/hmpps-welcome-people-into-prison-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-welcome-people-into-prison-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-welcome-people-into-prison-ui"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/hmpps-wmt-migration.tf
+++ b/terraform/hmpps-wmt-migration.tf
@@ -1,0 +1,16 @@
+module "hmpps-wmt-migration" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-wmt-migration"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/hmpps-workload.tf
+++ b/terraform/hmpps-workload.tf
@@ -1,0 +1,16 @@
+module "hmpps-workload" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-workload"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/keyworker-api.tf
+++ b/terraform/keyworker-api.tf
@@ -1,0 +1,16 @@
+module "keyworker-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "keyworker-api"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/legacy-ppud-api.tf
+++ b/terraform/legacy-ppud-api.tf
@@ -1,0 +1,16 @@
+module "legacy-ppud-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "legacy-ppud-api"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/licences.tf
+++ b/terraform/licences.tf
@@ -1,0 +1,16 @@
+module "licences" {
+  source     = "./modules/repository-collaborators"
+  repository = "licences"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/manage-a-workforce-ui.tf
+++ b/terraform/manage-a-workforce-ui.tf
@@ -1,0 +1,16 @@
+module "manage-a-workforce-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-a-workforce-ui"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/manage-key-workers.tf
+++ b/terraform/manage-key-workers.tf
@@ -1,0 +1,16 @@
+module "manage-key-workers" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-key-workers"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/manage-recalls-api.tf
+++ b/terraform/manage-recalls-api.tf
@@ -1,0 +1,16 @@
+module "manage-recalls-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-recalls-api"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/manage-recalls-error-pages.tf
+++ b/terraform/manage-recalls-error-pages.tf
@@ -1,0 +1,16 @@
+module "manage-recalls-error-pages" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-recalls-error-pages"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/manage-recalls-ui.tf
+++ b/terraform/manage-recalls-ui.tf
@@ -1,0 +1,16 @@
+module "manage-recalls-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-recalls-ui"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/manage-soc-cases-api.tf
+++ b/terraform/manage-soc-cases-api.tf
@@ -1,0 +1,16 @@
+module "manage-soc-cases-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-soc-cases-api"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/manage-soc-cases.tf
+++ b/terraform/manage-soc-cases.tf
@@ -1,0 +1,16 @@
+module "manage-soc-cases" {
+  source     = "./modules/repository-collaborators"
+  repository = "manage-soc-cases"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/nomis-api-terraform-azure.tf
+++ b/terraform/nomis-api-terraform-azure.tf
@@ -1,0 +1,16 @@
+module "nomis-api-terraform-azure" {
+  source     = "./modules/repository-collaborators"
+  repository = "nomis-api-terraform-azure"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/nomis-prisoner-deletion-service.tf
+++ b/terraform/nomis-prisoner-deletion-service.tf
@@ -1,0 +1,16 @@
+module "nomis-prisoner-deletion-service" {
+  source     = "./modules/repository-collaborators"
+  repository = "nomis-prisoner-deletion-service"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/nomis-user-roles-api.tf
+++ b/terraform/nomis-user-roles-api.tf
@@ -1,0 +1,16 @@
+module "nomis-user-roles-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "nomis-user-roles-api"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/offender-case-notes.tf
+++ b/terraform/offender-case-notes.tf
@@ -1,0 +1,16 @@
+module "offender-case-notes" {
+  source     = "./modules/repository-collaborators"
+  repository = "offender-case-notes"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/offender-events-ui.tf
+++ b/terraform/offender-events-ui.tf
@@ -1,0 +1,16 @@
+module "offender-events-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "offender-events-ui"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "maintain"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/offloc-server.tf
+++ b/terraform/offloc-server.tf
@@ -1,0 +1,16 @@
+module "offloc-server" {
+  source     = "./modules/repository-collaborators"
+  repository = "offloc-server"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/ppud-replacement-bandiera.tf
+++ b/terraform/ppud-replacement-bandiera.tf
@@ -1,0 +1,16 @@
+module "ppud-replacement-bandiera" {
+  source     = "./modules/repository-collaborators"
+  repository = "ppud-replacement-bandiera"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/ppud-replacement-dashboards.tf
+++ b/terraform/ppud-replacement-dashboards.tf
@@ -1,0 +1,16 @@
+module "ppud-replacement-dashboards" {
+  source     = "./modules/repository-collaborators"
+  repository = "ppud-replacement-dashboards"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/pre-sentence-service-wproofreader.tf
+++ b/terraform/pre-sentence-service-wproofreader.tf
@@ -1,0 +1,16 @@
+module "pre-sentence-service-wproofreader" {
+  source     = "./modules/repository-collaborators"
+  repository = "pre-sentence-service-wproofreader"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/pre-sentence-service.tf
+++ b/terraform/pre-sentence-service.tf
@@ -1,0 +1,16 @@
+module "pre-sentence-service" {
+  source     = "./modules/repository-collaborators"
+  repository = "pre-sentence-service"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prepare-a-case.tf
+++ b/terraform/prepare-a-case.tf
@@ -1,0 +1,16 @@
+module "prepare-a-case" {
+  source     = "./modules/repository-collaborators"
+  repository = "prepare-a-case"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prison-api.tf
+++ b/terraform/prison-api.tf
@@ -1,0 +1,16 @@
+module "prison-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-api"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prison-offender-events.tf
+++ b/terraform/prison-offender-events.tf
@@ -1,0 +1,16 @@
+module "prison-offender-events" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-offender-events"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prison-services-feedback-and-support.tf
+++ b/terraform/prison-services-feedback-and-support.tf
@@ -1,0 +1,16 @@
+module "prison-services-feedback-and-support" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-services-feedback-and-support"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prison-to-probation-update.tf
+++ b/terraform/prison-to-probation-update.tf
@@ -1,0 +1,16 @@
+module "prison-to-probation-update" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-to-probation-update"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prison-visits-2.tf
+++ b/terraform/prison-visits-2.tf
@@ -1,0 +1,16 @@
+module "prison-visits-2" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-visits-2"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prisoner-contact-registry.tf
+++ b/terraform/prisoner-contact-registry.tf
@@ -1,0 +1,16 @@
+module "prisoner-contact-registry" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-contact-registry"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prisoner-content-hub-backend.tf
+++ b/terraform/prisoner-content-hub-backend.tf
@@ -1,0 +1,16 @@
+module "prisoner-content-hub-backend" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-content-hub-backend"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prisoner-content-hub-feedback-exporter.tf
+++ b/terraform/prisoner-content-hub-feedback-exporter.tf
@@ -1,0 +1,16 @@
+module "prisoner-content-hub-feedback-exporter" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-content-hub-feedback-exporter"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prisoner-content-hub-frontend.tf
+++ b/terraform/prisoner-content-hub-frontend.tf
@@ -1,0 +1,16 @@
+module "prisoner-content-hub-frontend" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-content-hub-frontend"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prisoner-content-hub.tf
+++ b/terraform/prisoner-content-hub.tf
@@ -1,0 +1,16 @@
+module "prisoner-content-hub" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-content-hub"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/prisoner-offender-search.tf
+++ b/terraform/prisoner-offender-search.tf
@@ -1,0 +1,16 @@
+module "prisoner-offender-search" {
+  source     = "./modules/repository-collaborators"
+  repository = "prisoner-offender-search"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/probation-offender-search.tf
+++ b/terraform/probation-offender-search.tf
@@ -1,0 +1,16 @@
+module "probation-offender-search" {
+  source     = "./modules/repository-collaborators"
+  repository = "probation-offender-search"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/probation-teams.tf
+++ b/terraform/probation-teams.tf
@@ -1,0 +1,16 @@
+module "probation-teams" {
+  source     = "./modules/repository-collaborators"
+  repository = "probation-teams"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/send-legal-mail-to-prisons-api.tf
+++ b/terraform/send-legal-mail-to-prisons-api.tf
@@ -1,0 +1,16 @@
+module "send-legal-mail-to-prisons-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "send-legal-mail-to-prisons-api"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/send-legal-mail-to-prisons.tf
+++ b/terraform/send-legal-mail-to-prisons.tf
@@ -1,0 +1,16 @@
+module "send-legal-mail-to-prisons" {
+  source     = "./modules/repository-collaborators"
+  repository = "send-legal-mail-to-prisons"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/token-verification-api.tf
+++ b/terraform/token-verification-api.tf
@@ -1,0 +1,16 @@
+module "token-verification-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "token-verification-api"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/use-of-force.tf
+++ b/terraform/use-of-force.tf
@@ -1,0 +1,16 @@
+module "use-of-force" {
+  source     = "./modules/repository-collaborators"
+  repository = "use-of-force"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/visit-scheduler.tf
+++ b/terraform/visit-scheduler.tf
@@ -1,0 +1,16 @@
+module "visit-scheduler" {
+  source     = "./modules/repository-collaborators"
+  repository = "visit-scheduler"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/whereabouts-api.tf
+++ b/terraform/whereabouts-api.tf
@@ -1,0 +1,16 @@
+module "whereabouts-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "whereabouts-api"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/wmt-web.tf
+++ b/terraform/wmt-web.tf
@@ -1,0 +1,16 @@
+module "wmt-web" {
+  source     = "./modules/repository-collaborators"
+  repository = "wmt-web"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}

--- a/terraform/wmt-worker.tf
+++ b/terraform/wmt-worker.tf
@@ -1,0 +1,16 @@
+module "wmt-worker" {
+  source     = "./modules/repository-collaborators"
+  repository = "wmt-worker"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "push"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-26"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator emileswarts was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

