### PR TITLE
Remove expired collaborator from Terraform file/s for peter-bcl

### DIFF
--- a/terraform/hmpps-delius-api.tf
+++ b/terraform/hmpps-delius-api.tf
@@ -13,16 +13,6 @@ module "hmpps-delius-api" {
       review_after = "2023-02-25"
     },
     {
-      github_user  = "peter-bcl"
-      permission   = "push"
-      name         = "Peter Wilson"
-      email        = "pwilson@unilink.com"
-      org          = "Unilink"
-      reason       = "To enable Unilink to continue supplying development and testing services to HMPPS"
-      added_by     = "Nicola Hodgkinson <nicola.hodgkinson@justice.gov.uk>"
-      review_after = "2023-02-25"
-    },
-    {
       github_user  = "seanvalmonte"
       permission   = "push"
       name         = "Sean Valmonte"


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator peter-bcl review date has expired for the file/s contained in this pull request.

Either approve this pull request, modify it or delete it if it is no longer necessary.
