### PR TITLE
Add full Org member / collaborator to Terraform file/s for bjpirt

### DIFF
--- a/terraform/hmpps-adjustments-api.tf
+++ b/terraform/hmpps-adjustments-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-adjustments-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-adjustments-api"
+  collaborators = [
+    {
+      github_user  = "bjpirt"
+      permission   = "push"
+      name         = "ben pirt"
+      email        = "ben@madetech.com"
+      org          = "madetech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-05-30"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator bjpirt was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

