### PR TITLE
Add full Org member / collaborator to Terraform file/s for emileswarts

### DIFF
--- a/terraform/terraform-aws-panfw-bootstrap.tf
+++ b/terraform/terraform-aws-panfw-bootstrap.tf
@@ -1,0 +1,16 @@
+module "terraform-aws-panfw-bootstrap" {
+  source     = "./modules/repository-collaborators"
+  repository = "terraform-aws-panfw-bootstrap"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-02"
+    },
+  ]
+}

--- a/terraform/terraform-aws-step_function_globalprotect.tf
+++ b/terraform/terraform-aws-step_function_globalprotect.tf
@@ -1,0 +1,16 @@
+module "terraform-aws-step_function_globalprotect" {
+  source     = "./modules/repository-collaborators"
+  repository = "terraform-aws-step_function_globalprotect"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-02"
+    },
+  ]
+}

--- a/terraform/terraform-aws-vpc.tf
+++ b/terraform/terraform-aws-vpc.tf
@@ -1,0 +1,16 @@
+module "terraform-aws-vpc" {
+  source     = "./modules/repository-collaborators"
+  repository = "terraform-aws-vpc"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-02"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator emileswarts was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

