### PR TITLE
Add full Org member / collaborator to Terraform file/s for emileswarts

### DIFF
--- a/terraform/terraform-aws-panw-asg.tf
+++ b/terraform/terraform-aws-panw-asg.tf
@@ -1,0 +1,16 @@
+module "terraform-aws-panw-asg" {
+  source     = "./modules/repository-collaborators"
+  repository = "terraform-aws-panw-asg"
+  collaborators = [
+    {
+      github_user  = "emileswarts"
+      permission   = "admin"
+      name         = "emile swarts"
+      email        = "emile@madetech.com"
+      org          = "made tech ltd"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-05"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator emileswarts was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

