### PR TITLE
Add full Org member / collaborator to Terraform file/s for chubberlisk

### DIFF
--- a/terraform/basm-move-generator.tf
+++ b/terraform/basm-move-generator.tf
@@ -1,0 +1,16 @@
+module "basm-move-generator" {
+  source     = "./modules/repository-collaborators"
+  repository = "basm-move-generator"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/book-a-prison-visit-staff-ui.tf
+++ b/terraform/book-a-prison-visit-staff-ui.tf
@@ -1,0 +1,16 @@
+module "book-a-prison-visit-staff-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "book-a-prison-visit-staff-ui"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/calculate-release-dates-api.tf
+++ b/terraform/calculate-release-dates-api.tf
@@ -1,0 +1,16 @@
+module "calculate-release-dates-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "calculate-release-dates-api"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/calculate-release-dates.tf
+++ b/terraform/calculate-release-dates.tf
@@ -1,0 +1,16 @@
+module "calculate-release-dates" {
+  source     = "./modules/repository-collaborators"
+  repository = "calculate-release-dates"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/check-my-diary.tf
+++ b/terraform/check-my-diary.tf
@@ -1,0 +1,16 @@
+module "check-my-diary" {
+  source     = "./modules/repository-collaborators"
+  repository = "check-my-diary"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/cloud-platform-terraform-github-prototype.tf
+++ b/terraform/cloud-platform-terraform-github-prototype.tf
@@ -1,0 +1,16 @@
+module "cloud-platform-terraform-github-prototype" {
+  source     = "./modules/repository-collaborators"
+  repository = "cloud-platform-terraform-github-prototype"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/cmd-api.tf
+++ b/terraform/cmd-api.tf
@@ -1,0 +1,16 @@
+module "cmd-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "cmd-api"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/community-api.tf
+++ b/terraform/community-api.tf
@@ -1,0 +1,16 @@
+module "community-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "community-api"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/court-case-matcher.tf
+++ b/terraform/court-case-matcher.tf
@@ -1,0 +1,16 @@
+module "court-case-matcher" {
+  source     = "./modules/repository-collaborators"
+  repository = "court-case-matcher"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/court-case-service.tf
+++ b/terraform/court-case-service.tf
@@ -1,0 +1,16 @@
+module "court-case-service" {
+  source     = "./modules/repository-collaborators"
+  repository = "court-case-service"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/court-case-test-app.tf
+++ b/terraform/court-case-test-app.tf
@@ -1,0 +1,16 @@
+module "court-case-test-app" {
+  source     = "./modules/repository-collaborators"
+  repository = "court-case-test-app"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/court-register.tf
+++ b/terraform/court-register.tf
@@ -1,0 +1,16 @@
+module "court-register" {
+  source     = "./modules/repository-collaborators"
+  repository = "court-register"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/create-and-vary-a-licence-api.tf
+++ b/terraform/create-and-vary-a-licence-api.tf
@@ -1,0 +1,16 @@
+module "create-and-vary-a-licence-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "create-and-vary-a-licence-api"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/create-and-vary-a-licence.tf
+++ b/terraform/create-and-vary-a-licence.tf
@@ -1,0 +1,16 @@
+module "create-and-vary-a-licence" {
+  source     = "./modules/repository-collaborators"
+  repository = "create-and-vary-a-licence"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/csr-api.tf
+++ b/terraform/csr-api.tf
@@ -1,0 +1,16 @@
+module "csr-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "csr-api"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/deployment-tools.tf
+++ b/terraform/deployment-tools.tf
@@ -1,0 +1,16 @@
+module "deployment-tools" {
+  source     = "./modules/repository-collaborators"
+  repository = "deployment-tools"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "maintain"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/digital-prison-services.tf
+++ b/terraform/digital-prison-services.tf
@@ -1,0 +1,16 @@
+module "digital-prison-services" {
+  source     = "./modules/repository-collaborators"
+  repository = "digital-prison-services"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/dps-data-compliance.tf
+++ b/terraform/dps-data-compliance.tf
@@ -1,0 +1,16 @@
+module "dps-data-compliance" {
+  source     = "./modules/repository-collaborators"
+  repository = "dps-data-compliance"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/dps-gradle-spring-boot.tf
+++ b/terraform/dps-gradle-spring-boot.tf
@@ -1,0 +1,16 @@
+module "dps-gradle-spring-boot" {
+  source     = "./modules/repository-collaborators"
+  repository = "dps-gradle-spring-boot"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/dps-monitor.tf
+++ b/terraform/dps-monitor.tf
@@ -1,0 +1,16 @@
+module "dps-monitor" {
+  source     = "./modules/repository-collaborators"
+  repository = "dps-monitor"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/dps-project-bootstrap.tf
+++ b/terraform/dps-project-bootstrap.tf
@@ -1,0 +1,16 @@
+module "dps-project-bootstrap" {
+  source     = "./modules/repository-collaborators"
+  repository = "dps-project-bootstrap"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/education-data-aggregation.tf
+++ b/terraform/education-data-aggregation.tf
@@ -1,0 +1,16 @@
+module "education-data-aggregation" {
+  source     = "./modules/repository-collaborators"
+  repository = "education-data-aggregation"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/education-skills-work-employment.tf
+++ b/terraform/education-skills-work-employment.tf
@@ -1,0 +1,16 @@
+module "education-skills-work-employment" {
+  source     = "./modules/repository-collaborators"
+  repository = "education-skills-work-employment"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/elp-scripts.tf
+++ b/terraform/elp-scripts.tf
@@ -1,0 +1,16 @@
+module "elp-scripts" {
+  source     = "./modules/repository-collaborators"
+  repository = "elp-scripts"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/help-with-prison-visits-asynchronous-worker.tf
+++ b/terraform/help-with-prison-visits-asynchronous-worker.tf
@@ -1,0 +1,16 @@
+module "help-with-prison-visits-asynchronous-worker" {
+  source     = "./modules/repository-collaborators"
+  repository = "help-with-prison-visits-asynchronous-worker"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/help-with-prison-visits-database.tf
+++ b/terraform/help-with-prison-visits-database.tf
@@ -1,0 +1,16 @@
+module "help-with-prison-visits-database" {
+  source     = "./modules/repository-collaborators"
+  repository = "help-with-prison-visits-database"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/help-with-prison-visits-external.tf
+++ b/terraform/help-with-prison-visits-external.tf
@@ -1,0 +1,16 @@
+module "help-with-prison-visits-external" {
+  source     = "./modules/repository-collaborators"
+  repository = "help-with-prison-visits-external"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/help-with-prison-visits-internal.tf
+++ b/terraform/help-with-prison-visits-internal.tf
@@ -1,0 +1,16 @@
+module "help-with-prison-visits-internal" {
+  source     = "./modules/repository-collaborators"
+  repository = "help-with-prison-visits-internal"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/help-with-prison-visits-maintenance.tf
+++ b/terraform/help-with-prison-visits-maintenance.tf
@@ -1,0 +1,16 @@
+module "help-with-prison-visits-maintenance" {
+  source     = "./modules/repository-collaborators"
+  repository = "help-with-prison-visits-maintenance"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-activities-management-api.tf
+++ b/terraform/hmpps-activities-management-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-activities-management-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-activities-management-api"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-activities-management.tf
+++ b/terraform/hmpps-activities-management.tf
@@ -1,0 +1,16 @@
+module "hmpps-activities-management" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-activities-management"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-allocations.tf
+++ b/terraform/hmpps-allocations.tf
@@ -1,0 +1,16 @@
+module "hmpps-allocations" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-allocations"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-approved-premises-api.tf
+++ b/terraform/hmpps-approved-premises-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-approved-premises-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-approved-premises-api"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-approved-premises-ui.tf
+++ b/terraform/hmpps-approved-premises-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-approved-premises-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-approved-premises-ui"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-architecture-as-code.tf
+++ b/terraform/hmpps-architecture-as-code.tf
@@ -1,0 +1,16 @@
+module "hmpps-architecture-as-code" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-architecture-as-code"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-assess-risks-and-needs.tf
+++ b/terraform/hmpps-assess-risks-and-needs.tf
@@ -1,0 +1,16 @@
+module "hmpps-assess-risks-and-needs" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-assess-risks-and-needs"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-audit-poc-api.tf
+++ b/terraform/hmpps-audit-poc-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-audit-poc-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-audit-poc-api"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-audit-poc-ui.tf
+++ b/terraform/hmpps-audit-poc-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-audit-poc-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-audit-poc-ui"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-auth-performance-tests.tf
+++ b/terraform/hmpps-auth-performance-tests.tf
@@ -1,0 +1,16 @@
+module "hmpps-auth-performance-tests" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-auth-performance-tests"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-auth.tf
+++ b/terraform/hmpps-auth.tf
@@ -1,0 +1,16 @@
+module "hmpps-auth" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-auth"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-authorization-server.tf
+++ b/terraform/hmpps-authorization-server.tf
@@ -1,0 +1,16 @@
+module "hmpps-authorization-server" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-authorization-server"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-book-a-prison-visit-ui.tf
+++ b/terraform/hmpps-book-a-prison-visit-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-book-a-prison-visit-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-book-a-prison-visit-ui"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-book-video-link.tf
+++ b/terraform/hmpps-book-video-link.tf
@@ -1,0 +1,16 @@
+module "hmpps-book-video-link" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-book-video-link"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-circleci-orb.tf
+++ b/terraform/hmpps-circleci-orb.tf
@@ -1,0 +1,16 @@
+module "hmpps-circleci-orb" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-circleci-orb"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-community-accommodation-wiremock.tf
+++ b/terraform/hmpps-community-accommodation-wiremock.tf
@@ -1,0 +1,16 @@
+module "hmpps-community-accommodation-wiremock" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-community-accommodation-wiremock"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-community-api-wiremock.tf
+++ b/terraform/hmpps-community-api-wiremock.tf
@@ -1,0 +1,16 @@
+module "hmpps-community-api-wiremock" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-community-api-wiremock"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-delius-api.tf
+++ b/terraform/hmpps-delius-api.tf
@@ -32,5 +32,15 @@ module "hmpps-delius-api" {
       added_by     = "Nicola Hodgkinson <nicola.hodgkinson@justice.gov.uk>"
       review_after = "2023-08-25"
     },
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
   ]
 }

--- a/terraform/hmpps-digital-developer-recruitment.tf
+++ b/terraform/hmpps-digital-developer-recruitment.tf
@@ -1,0 +1,16 @@
+module "hmpps-digital-developer-recruitment" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-digital-developer-recruitment"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "pull"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-domain-event-logger.tf
+++ b/terraform/hmpps-domain-event-logger.tf
@@ -1,0 +1,16 @@
+module "hmpps-domain-event-logger" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-domain-event-logger"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-domain-events.tf
+++ b/terraform/hmpps-domain-events.tf
@@ -1,0 +1,16 @@
+module "hmpps-domain-events" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-domain-events"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-education-employment-api.tf
+++ b/terraform/hmpps-education-employment-api.tf
@@ -1,0 +1,16 @@
+module "hmpps-education-employment-api" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-education-employment-api"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "push"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}

--- a/terraform/hmpps-engineering-accelerator-team.tf
+++ b/terraform/hmpps-engineering-accelerator-team.tf
@@ -1,0 +1,16 @@
+module "hmpps-engineering-accelerator-team" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-engineering-accelerator-team"
+  collaborators = [
+    {
+      github_user  = "chubberlisk"
+      permission   = "pull"
+      name         = "wen ting wang"
+      email        = "wen.tingwang@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-08"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator chubberlisk was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

