### PR TITLE
Modify permission in Terraform file/s for emileswarts

### DIFF
--- a/terraform/prepare-a-case.tf
+++ b/terraform/prepare-a-case.tf
@@ -34,7 +34,7 @@ module "prepare-a-case" {
     },
     {
       github_user  = "emileswarts"
-      permission   = "push"
+      permission   = "pull"
       name         = "emile swarts"
       email        = "emile@madetech.com"
       org          = "Made Tech"


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator emileswarts permission on Github is different to the permission in the Terraform file for the repository.

This is because the collaborator is a full organization member, is able to join repositories outside of Terraform and may have different access to the repository now they are in a Team.

The permission on Github is given the priority.

This pull request ensures we keep track of those collaborators, which repositories they are accessing and their permission.

Permission can either be admin, push, maintain, pull or triage.

