### PR TITLE
Add full Org member / collaborator to Terraform file/s for aprilmd

### DIFF
--- a/terraform/hmpps-registers.tf
+++ b/terraform/hmpps-registers.tf
@@ -1,0 +1,16 @@
+module "hmpps-registers" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-registers"
+  collaborators = [
+    {
+      github_user  = "aprilmd"
+      permission   = "push"
+      name         = "april dawson"
+      email        = "april.dawson@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-20"
+    },
+  ]
+}

--- a/terraform/prison-register.tf
+++ b/terraform/prison-register.tf
@@ -1,0 +1,16 @@
+module "prison-register" {
+  source     = "./modules/repository-collaborators"
+  repository = "prison-register"
+  collaborators = [
+    {
+      github_user  = "aprilmd"
+      permission   = "push"
+      name         = "april dawson"
+      email        = "april.dawson@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-20"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator aprilmd was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

