### PR TITLE
Add full Org member / collaborator to Terraform file/s for mcoffey-mt

### DIFF
--- a/terraform/hmpps-accredited-programmes-ui.tf
+++ b/terraform/hmpps-accredited-programmes-ui.tf
@@ -1,0 +1,16 @@
+module "hmpps-accredited-programmes-ui" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-accredited-programmes-ui"
+  collaborators = [
+    {
+      github_user  = "mcoffey-mt"
+      permission   = "push"
+      name         = "matthew coffey"
+      email        = "matthew.coffey@digital.justice.gov.uk"
+      org          = "made tech"
+      reason       = "Full Org member / collaborator missing from Terraform file"
+      added_by     = "opseng-bot@digital.justice.gov.uk"
+      review_after = "2023-06-22"
+    },
+  ]
+}


### PR DESCRIPTION
Hi there

This is the GitHub-Collaborator repository bot.

The collaborator mcoffey-mt was found to be missing from the file/s in this pull request.

This is because the collaborator is a full organization member and is able to join repositories outside of Terraform.

This pull request ensures we keep track of those collaborators and which repositories they are accessing.

Edit the pull request file/s because some of the data about the collaborator is missing.

