### PR TITLE
Adds Weblate bot to demo translation project

### DIFF
--- a/terraform/opg-weblate-demo-translation-project.tf
+++ b/terraform/opg-weblate-demo-translation-project.tf
@@ -1,0 +1,16 @@
+module "opg-weblate-demo-translation-project" {
+  source     = "./modules/repository-collaborators"
+  repository = "opg-weblate-demo-translation-project"
+  collaborators = [
+    {
+      github_user  = "weblate"
+      permission   = "push"
+      name         = "Weblate Push User"
+      email        = "hosted@weblate.org"
+      org          = "Ministry of Justice"
+      reason       = "Used by Weblate"
+      added_by     = "andrew.pearce@digital.justice.gov.uk"
+      review_after = "2024-10-10"
+    },
+  ]
+}


### PR DESCRIPTION
This PR adds the Weblate bot (outside collaborator) to the opg-weblate-demo-translation-project repo.

Requested via https://github.com/ministryofjustice/github-collaborators/issues/1993