### PR TITLE
Add collaborator to GitHub Collaborators

### DIFF
--- a/terraform/github-collaborators.tf
+++ b/terraform/github-collaborators.tf
@@ -1,0 +1,16 @@
+module "github-collaborators" {
+  source     = "./modules/repository-collaborators"
+  repository = "github-collaborators"
+  collaborators = [
+    {
+      github_user  = "richardcane"
+      permission   = "push"
+      name         = "Richard Cane"
+      email        = "richard.cane@madetech.com"
+      org          = "Madetech"
+      reason       = "To allow collaborator to raise PRs to manage off-boarding of other collaborators"
+      added_by     = "antony.bishop@digital.justice.gov.uk"
+      review_after = "2024-12-27"
+    },
+  ]
+}


### PR DESCRIPTION
## 👀 Purpose

This PR adds a new collaborator to GitHub Collaborators repo. At present collaborators can't create branches to submit PRs for changes to their teams and remove or add users to their repos. This results in either a forked PR, which fails checks and means that either Operations Engineering has to replicate the PR, or manually create a PR from a submitted issue.

This will allow better self-service for this team and reduce manual intervention from Ops Eng.

## ♻️ What's changed

- Added collaborator