### PR TITLE
Updated repo name in tf file

### DIFF
--- a/terraform/alpha_cjs_va_dashboard.tf
+++ b/terraform/alpha_cjs_va_dashboard.tf
@@ -1,6 +1,6 @@
 module "alpha_cjs_va_dashboard" {
   source     = "./modules/repository-collaborators"
-  repository = "alpha_cjs_va_dashboard"
+  repository = "alpha-cjs-va-dashboard"
   collaborators = [
     {
       github_user  = "lewissheppard"


### PR DESCRIPTION
Hello 
We have a couple of outside collaborators working on the alpha cjs va dashboard project. Due to cloud deployment requirements, we are forced to change the name of the repo to alpha-cis-va-dashboard. I have now updated the tf file with the new repo name. 

If there are any more changes required anywhere else, please let me know. 

Thanks,
Vinoth Mohanram
