### PR TITLE
:recycle: Updated rexml version from 3.2.8 -> 3.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     public_suffix (5.0.3)
     rake (13.0.6)
     rchardet (1.8.0)
-    rexml (3.2.8)
+    rexml (3.3.2)
       strscan (>= 3.0.9)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)


### PR DESCRIPTION
## 👀 Purpose

To mitigate this [vulnerability](https://github.com/ruby/rexml/security/advisories/GHSA-4xqq-m2hx-25v8) in the rexml package.

## ♻️ What's Changed

- rexml version updated from 3.2.8 -> 3.3.2

## 📝 Notes

No notes to speak of.