### PR TITLE
:recycle: Added Flag for Ignoring Moderate Dependencies

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -28,4 +28,4 @@ jobs:
         run: bundle exec rspec
       - name: Run depedency audit
         run: |
-          bundle exec bundler-audit
+          bundle exec bundler-audit check --ignore-moderate


### PR DESCRIPTION
## 👀 Purpose

Medium dependency vulnerabilities are being picked up by the Rspec workflow. This tag should prevent the workflow from reporting on these, as we only want to know about vulnerabilities that are HIGH or above.

## ♻️ What's Changed

- `check --ignore-moderate tag` added to `bundler-audit` command.

## 📝 Notes

No notes to speak of.