### PR TITLE
Add 2 external collaborators

### DIFF
--- a/terraform/c100-application.tf
+++ b/terraform/c100-application.tf
@@ -1,0 +1,26 @@
+module "c100-application" {
+  source     = "./modules/repository-collaborators"
+  repository = "c100-application"
+  collaborators = [
+    {
+      github_user  = "sgmselli"
+      permission   = "push"
+      name         = "Matthew Sellings"
+      email        = "Matthew.Sellings@HMCTS.NET"
+      org          = "Solirius"
+      reason       = "For work on the c100 application"
+      added_by     = "avi.singh@justice.gov.uk"
+      review_after = "2024-11-30"
+    },
+    {
+      github_user  = "DanielleKushnir"
+      permission   = "push"
+      name         = "Danielle Kushnir"
+      email        = "Danielle.Kushnir@HMCTS.NET"
+      org          = "Solirius"
+      reason       = "For work on the c100 application"
+      added_by     = "avi.singh@justice.gov.uk"
+      review_after = "2024-11-30"
+    }
+  ]
+}


### PR DESCRIPTION
Adds 2 new external collaborators

[Issue #218](https://github.com/ministryofjustice/github-collaborators/issues/2181#issue-2478134641)

- review date set to 2024-11-30 (not todays date)
- added by = avi.singh@justice.gov.uk
- reason: For work on c100-application

usernames

sgmselli
DanielleKushnir
names

Matthew Sellings
Danielle Kushnir
emails

[Matthew.Sellings@HMCTS.NET](mailto:Matthew.Sellings@HMCTS.NET)
[Danielle.Kushnir@HMCTS.NET](mailto:Danielle.Kushnir@HMCTS.NET)
org

ministryofjustice
reason

C100
added_by

[kalvin.lyu@hmcts.net](mailto:kalvin.lyu@hmcts.net)
review_after

2024-08-21
permission

push
repositories

https://github.com/ministryofjustice/c100-application