### PR TITLE
Add outside collaborator

### DIFF
--- a/terraform/yjsm-ui.tf
+++ b/terraform/yjsm-ui.tf
@@ -82,5 +82,15 @@ module "yjsm-ui" {
       added_by     = "David.Hall@yjb.gov.uk"
       review_after = "2025-03-01"
     },
+    {
+      github_user  = "fabiosalvarezza"
+      permission   = "push"
+      name         = "Fabio Salvarezza"
+      email        = "fabio.salvarezza@necsws.com"
+      org          = "NEC SWS"
+      reason       = "Existing developer"
+      added_by     = "David.Hall@yjb.gov.uk"
+      review_after = "2025-09-02"
+    },
   ]
 }


### PR DESCRIPTION
PR to add Fabio Salvarezza as an outside collaborator [#2205](https://github.com/ministryofjustice/github-collaborators/issues/2205#issue-2501204211)

Use this issue template if you do not feel comfortable raising a PR with the required changes to files in the terraform/ directory.

Please supply all the requested information, so that your request can be processed as quickly as possible.
Which MoJ repository/s are you requesting access to (e.g. money-to-prisoners)?

yjsm-ui
What is the GitHub username of the person who needs access?

fabiosalvarezza
What is their full name?

Fabio Salvarezza
What is their email address?

[fabio.salvarezza@necsws.com](mailto:fabio.salvarezza@necsws.com)
What company/organisation do they belong to (e.g. "Department for Education")?

NEC
What level of access should they have?

    Read
    Triage
    Write
    Maintain
    Admin

Why is this access being requested?

Fix Snyk security vulnerabilities exposed by this project
Which MoJ team/person is responsible for this request? This must be a ".justice.gov.uk" or ".digital.justice.gov.uk" email address.

[jo.harvey@necsws.com](mailto:jo.harvey@necsws.com)
This should be an email address awesome.team@digital.justice.gov.uk

Team email addresses are preferred, rather than individual email addresses, to make it easier to follow-up at a later date.
Review date

02/09/2025
Date after which this collaborator's access should be reviewed. This should be a date in the format: 2021-01-15, no more than one year into the future from today.