### PR TITLE
Add external collaborators for HMPPS CAS project

### DIFF
--- a/terraform/hmpps-community-accommodation-tier-2-bail-prototypes.tf
+++ b/terraform/hmpps-community-accommodation-tier-2-bail-prototypes.tf
@@ -1,0 +1,36 @@
+module "hmpps-community-accommodation-tier-2-bail-prototypes" {
+  source     = "./modules/repository-collaborators"
+  repository = "hmpps-community-accommodation-tier-2-bail-prototypes"
+  collaborators = [
+    {
+      github_user  = "apdig"
+      permission   = "push"
+      name         = "André Petheram"
+      email        = "andre.petheram@oxfordinsights.com"
+      org          = "Oxford Insights"
+      reason       = "CAS 2 Bail Alpha Development"
+      added_by     = "ross.jones@digital.justice.gov.uk"
+      review_after = "2025-06-31"
+    },
+    {
+      github_user  = "chrisadesign"
+      permission   = "push"
+      name         = "Chris Armstrong"
+      email        = "mail@chrisarmstrong.io"
+      org          = "Oxford Insights"
+      reason       = "CAS 2 Bail Alpha Development"
+      added_by     = "ross.jones@digital.justice.gov.uk"
+      review_after = "2025-06-31"
+    },
+    {
+      github_user  = "simonwo"
+      permission   = "push"
+      name         = "Simon Worthington"
+      email        = "simon@register-dynamics.co.uk"
+      org          = "Oxford Insights"
+      reason       = "CAS 2 Bail Alpha Development"
+      added_by     = "ross.jones@digital.justice.gov.uk"
+      review_after = "2025-06-31"
+    }
+  ]
+}


### PR DESCRIPTION
Adds three external contributors for the CAS 2 Bail project alphas so that they can have write access.